### PR TITLE
Add information on what mods are installed to the checksums.json when installing

### DIFF
--- a/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
+++ b/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.3.3</AssemblyVersion>
-        <FileVersion>0.3.3</FileVersion>
+        <AssemblyVersion>0.4.0</AssemblyVersion>
+        <FileVersion>0.4.0</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller-cli</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaCommandLine</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaGUI/Models/ModModel.cs
+++ b/ModsOfMistriaGUI/Models/ModModel.cs
@@ -16,6 +16,7 @@ public class ModModel: ObservableObject
     {
         Mod = mod;
         CanInstall = mod.CanInstall();
+        _enabled = mod.IsInstalled();
     }
 
     public ModModel()

--- a/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
+++ b/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.3.3</AssemblyVersion>
-        <FileVersion>0.3.3</FileVersion>
+        <AssemblyVersion>0.4.0</AssemblyVersion>
+        <FileVersion>0.4.0</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaGUI</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaGUI/ViewModels/ModlistPageViewModel.cs
+++ b/ModsOfMistriaGUI/ViewModels/ModlistPageViewModel.cs
@@ -38,7 +38,7 @@ public partial class ModlistPageViewModel : PageViewBase
         
         if (Directory.Exists(ModsLocation))
         {
-            var mods = MistriaLocator.GetMods(ModsLocation);
+            var mods = MistriaLocator.GetMods(MistriaLocation, ModsLocation);
 
             new ModInstaller(MistriaLocation, ModsLocation).ValidateMods(mods);
 

--- a/ModsOfMistriaInstallerLib/GeneratedInformationWithMod.cs
+++ b/ModsOfMistriaInstallerLib/GeneratedInformationWithMod.cs
@@ -1,0 +1,8 @@
+﻿using Garethp.ModsOfMistriaInstallerLib.ModTypes;
+
+namespace Garethp.ModsOfMistriaInstallerLib;
+
+public class GeneratedInformationWithMod(IMod mod) : GeneratedInformation
+{
+    public IMod Mod { get; } = mod;
+}

--- a/ModsOfMistriaInstallerLib/Installer/ChecksumInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ChecksumInstaller.cs
@@ -4,6 +4,18 @@ namespace Garethp.ModsOfMistriaInstallerLib.Installer;
 
 public class ChecksumInstaller
 {
+    private readonly List<string> _customKeys =
+    [
+        "mods_installed",
+        "mods",
+        "graphics_mods",
+        "dll_mods",
+        "fiddle_mods",
+        "t2_mods",
+        "cutscene_mods",
+        "other_mods"
+    ];
+    
     public void Install(
         string fieldsOfMistriaLocation,
         string modsLocation,
@@ -12,24 +24,9 @@ public class ChecksumInstaller
         ) {
         var checksums = JObject.Parse(File.ReadAllText(Path.Combine(fieldsOfMistriaLocation, "checksums.json")));
         
-        var modsInstalled = new JArray();
-        
-        foreach (var mod in mods)
+        foreach (var key in _customKeys)
         {
-            var modInformation = new JObject();
-            modInformation["id"] = mod.Mod.GetId();
-            modInformation["name"] = mod.Mod.GetName();
-            modInformation["author"] = mod.Mod.GetAuthor();
-            modInformation["version"] = mod.Mod.GetVersion();
-            
-            modInformation["graphics"] = mod.Sprites.Count > 0 || mod.Tilesets.Count > 0;
-            modInformation["dll"] = mod.AurieMods.Count > 0;
-            modInformation["fiddle"] = mod.Fiddles.Count > 0 || mod.StoreCategories.Count > 0 || mod.StoreItems.Count > 0;
-            modInformation["t2"] = mod.Localisations.Count > 0 || mod.Conversations.Count > 0 || mod.Schedules.Count > 0;
-            modInformation["cutscenes"] = mod.Cutscenes.Count > 0;
-            modInformation["other"] = mod.Points.Count > 0 || mod.Outlines.Count > 0 || mod.AssetParts.Count > 0;
-            
-            modsInstalled.Add(modInformation);
+            checksums.Remove(key);
         }
 
         checksums["mist"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__mist__.json")).Length;
@@ -37,16 +34,42 @@ public class ChecksumInstaller
         checksums["t2_input"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_input.json")).Length;
         checksums["t2_output"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_output.json")).Length;
         checksums["localization"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "localization.json")).Length;
-        checksums["mods_installed"] = true;
-        
-        checksums["graphics_mods"] = modsInstalled.Any(mod => mod["graphics"]?.Value<bool>() == true);
-        checksums["dll_mods"] = modsInstalled.Any(mod => mod["dll"]?.Value<bool>() == true);
-        checksums["fiddle_mods"] = modsInstalled.Any(mod => mod["fiddle"]?.Value<bool>() == true);
-        checksums["t2_mods"] = modsInstalled.Any(mod => mod["t2"]?.Value<bool>() == true);
-        checksums["cutscene_mods"] = modsInstalled.Any(mod => mod["cutscene"]?.Value<bool>() == true);
-        checksums["other_mods"] = modsInstalled.Any(mod => mod["other"]?.Value<bool>() == true);
-        
-        checksums["mods"] = modsInstalled;
+
+        if (mods.Count > 0)
+        {
+            var modsInstalled = new JArray();
+
+            foreach (var mod in mods)
+            {
+                var modInformation = new JObject();
+                modInformation["id"] = mod.Mod.GetId();
+                modInformation["name"] = mod.Mod.GetName();
+                modInformation["author"] = mod.Mod.GetAuthor();
+                modInformation["version"] = mod.Mod.GetVersion();
+
+                modInformation["graphics"] = mod.Sprites.Count > 0 || mod.Tilesets.Count > 0;
+                modInformation["dll"] = mod.AurieMods.Count > 0;
+                modInformation["fiddle"] =
+                    mod.Fiddles.Count > 0 || mod.StoreCategories.Count > 0 || mod.StoreItems.Count > 0;
+                modInformation["t2"] = mod.Localisations.Count > 0 || mod.Conversations.Count > 0 ||
+                                       mod.Schedules.Count > 0;
+                modInformation["cutscenes"] = mod.Cutscenes.Count > 0;
+                modInformation["other"] = mod.Points.Count > 0 || mod.Outlines.Count > 0 || mod.AssetParts.Count > 0;
+
+                modsInstalled.Add(modInformation);
+            }
+
+            checksums["mods_installed"] = true;
+
+            checksums["graphics_mods"] = modsInstalled.Any(mod => mod["graphics"]?.Value<bool>() == true);
+            checksums["dll_mods"] = modsInstalled.Any(mod => mod["dll"]?.Value<bool>() == true);
+            checksums["fiddle_mods"] = modsInstalled.Any(mod => mod["fiddle"]?.Value<bool>() == true);
+            checksums["t2_mods"] = modsInstalled.Any(mod => mod["t2"]?.Value<bool>() == true);
+            checksums["cutscene_mods"] = modsInstalled.Any(mod => mod["cutscene"]?.Value<bool>() == true);
+            checksums["other_mods"] = modsInstalled.Any(mod => mod["other"]?.Value<bool>() == true);
+
+            checksums["mods"] = modsInstalled;
+        }
 
         File.WriteAllText(
             Path.Combine(fieldsOfMistriaLocation, "checksums.json"),
@@ -58,17 +81,7 @@ public class ChecksumInstaller
     {
         var checksums = JObject.Parse(File.ReadAllText(Path.Combine(fieldsOfMistriaLocation, "checksums.json")));
 
-        var keysToRemove = new List<string>()
-        {
-            "mods_installed",
-            "mods",
-            "graphics_mods",
-            "dll_mods",
-            "fiddle_mods",
-            "t2_mods",
-            "cutscene_mods",
-            "other_mods"
-        };
+
 
         checksums["mist"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__mist__.json")).Length;
         checksums["fiddle"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__fiddle__.json")).Length;
@@ -76,9 +89,9 @@ public class ChecksumInstaller
         checksums["t2_output"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_output.json")).Length;
         checksums["localization"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "localization.json")).Length;
 
-        foreach (var key in keysToRemove)
+        foreach (var key in _customKeys)
         {
-            if (checksums[key] is not null) checksums.Remove(key);
+            checksums.Remove(key);
         }
 
         File.WriteAllText(

--- a/ModsOfMistriaInstallerLib/Installer/ChecksumInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ChecksumInstaller.cs
@@ -2,16 +2,35 @@
 
 namespace Garethp.ModsOfMistriaInstallerLib.Installer;
 
-[InformationInstaller(1)]
-public class ChecksumInstaller: IModuleInstaller
+public class ChecksumInstaller
 {
     public void Install(
         string fieldsOfMistriaLocation,
         string modsLocation,
-        GeneratedInformation information,
+        List<GeneratedInformationWithMod> mods,
         Action<string, string> reportStatus
         ) {
         var checksums = JObject.Parse(File.ReadAllText(Path.Combine(fieldsOfMistriaLocation, "checksums.json")));
+        
+        var modsInstalled = new JArray();
+        
+        foreach (var mod in mods)
+        {
+            var modInformation = new JObject();
+            modInformation["id"] = mod.Mod.GetId();
+            modInformation["name"] = mod.Mod.GetName();
+            modInformation["author"] = mod.Mod.GetAuthor();
+            modInformation["version"] = mod.Mod.GetVersion();
+            
+            modInformation["graphics"] = mod.Sprites.Count > 0 || mod.Tilesets.Count > 0;
+            modInformation["dll"] = mod.AurieMods.Count > 0;
+            modInformation["fiddle"] = mod.Fiddles.Count > 0 || mod.StoreCategories.Count > 0 || mod.StoreItems.Count > 0;
+            modInformation["t2"] = mod.Localisations.Count > 0 || mod.Conversations.Count > 0 || mod.Schedules.Count > 0;
+            modInformation["cutscenes"] = mod.Cutscenes.Count > 0;
+            modInformation["other"] = mod.Points.Count > 0 || mod.Outlines.Count > 0 || mod.AssetParts.Count > 0;
+            
+            modsInstalled.Add(modInformation);
+        }
 
         checksums["mist"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__mist__.json")).Length;
         checksums["fiddle"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__fiddle__.json")).Length;
@@ -19,6 +38,15 @@ public class ChecksumInstaller: IModuleInstaller
         checksums["t2_output"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_output.json")).Length;
         checksums["localization"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "localization.json")).Length;
         checksums["mods_installed"] = true;
+        
+        checksums["graphics_mods"] = modsInstalled.Any(mod => mod["graphics"]?.Value<bool>() == true);
+        checksums["dll_mods"] = modsInstalled.Any(mod => mod["dll"]?.Value<bool>() == true);
+        checksums["fiddle_mods"] = modsInstalled.Any(mod => mod["fiddle"]?.Value<bool>() == true);
+        checksums["t2_mods"] = modsInstalled.Any(mod => mod["t2"]?.Value<bool>() == true);
+        checksums["cutscene_mods"] = modsInstalled.Any(mod => mod["cutscene"]?.Value<bool>() == true);
+        checksums["other_mods"] = modsInstalled.Any(mod => mod["other"]?.Value<bool>() == true);
+        
+        checksums["mods"] = modsInstalled;
 
         File.WriteAllText(
             Path.Combine(fieldsOfMistriaLocation, "checksums.json"),
@@ -30,15 +58,27 @@ public class ChecksumInstaller: IModuleInstaller
     {
         var checksums = JObject.Parse(File.ReadAllText(Path.Combine(fieldsOfMistriaLocation, "checksums.json")));
 
+        var keysToRemove = new List<string>()
+        {
+            "mods_installed",
+            "mods",
+            "graphics_mods",
+            "dll_mods",
+            "fiddle_mods",
+            "t2_mods",
+            "cutscene_mods",
+            "other_mods"
+        };
+
         checksums["mist"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__mist__.json")).Length;
         checksums["fiddle"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "__fiddle__.json")).Length;
         checksums["t2_input"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_input.json")).Length;
         checksums["t2_output"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "t2_output.json")).Length;
         checksums["localization"] = new FileInfo(Path.Combine(fieldsOfMistriaLocation, "localization.json")).Length;
-        
-        if (checksums["mods_installed"] is not null)
+
+        foreach (var key in keysToRemove)
         {
-            checksums.Remove("mods_installed");
+            if (checksums[key] is not null) checksums.Remove(key);
         }
 
         File.WriteAllText(

--- a/ModsOfMistriaInstallerLib/ModInstaller.cs
+++ b/ModsOfMistriaInstallerLib/ModInstaller.cs
@@ -104,18 +104,28 @@ public class ModInstaller(string fieldsOfMistriaLocation, string modsLocation)
             });
         }
 
-        var generatedInformation = new GeneratedInformation();
+        var generatedInformation = new List<GeneratedInformationWithMod>();
 
         var desiredGenerators = GetGenerators();
         var desiredInstallers = GetInstallers();
         
         foreach (var mod in mods)
         {
+            var informationWithMod = new GeneratedInformationWithMod(mod);
+            
             reportStatus(string.Format(Resources.GeneratingInformationForMod, mod.GetId()), "");
             foreach (var generator in desiredGenerators.Where(generator => generator.CanGenerate(mod)))
             {
-                generatedInformation.Merge(generator.Generate(mod));
+                informationWithMod.Merge(generator.Generate(mod));
             }
+            
+            generatedInformation.Add(informationWithMod);
+        }
+
+        var finalizedInformation = new GeneratedInformation();
+        foreach (var information in generatedInformation)
+        {
+            finalizedInformation.Merge(information);
         }
 
         var timer = new Stopwatch();
@@ -123,7 +133,7 @@ public class ModInstaller(string fieldsOfMistriaLocation, string modsLocation)
         foreach (var installer in desiredInstallers)
         {
             timer.Restart();
-            installer.Install(fieldsOfMistriaLocation, modsLocation, generatedInformation, reportStatus);
+            installer.Install(fieldsOfMistriaLocation, modsLocation, finalizedInformation, reportStatus);
             timer.Stop();
             reportStatus(installer.GetType().Name, timer.ToString());
         }

--- a/ModsOfMistriaInstallerLib/ModTypes/FolderMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/FolderMod.cs
@@ -21,6 +21,8 @@ public class FolderMod : IMod
     private string _manifestVersion;
 
     private Validation _validation = new();
+
+    private bool _isInstalled = false;
     
     public string Id
     {
@@ -44,6 +46,10 @@ public class FolderMod : IMod
     public string GetManifestVersion() => _manifestVersion;
 
     public Validation GetValidation() => _validation;
+    
+    public bool IsInstalled() => _isInstalled;
+    
+    public void SetInstalled(bool installed) => _isInstalled = installed;
 
     public string GetBasePath() => _location;
 

--- a/ModsOfMistriaInstallerLib/ModTypes/IMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/IMod.cs
@@ -19,6 +19,10 @@ public interface IMod
     public Validation GetValidation();
 
     public string GetId();
+    
+    public bool IsInstalled();
+
+    public void SetInstalled(bool installed);
 
     public Validation Validate();
 
@@ -29,8 +33,7 @@ public interface IMod
     public bool HasFilesInFolder(string folder, string extension);
     
     public bool HasFilesInFolder(string folder);
-
-
+    
     public List<string> GetFilesInFolder(string folder, string extension);
     
     public List<string> GetFilesInFolder(string folder);

--- a/ModsOfMistriaInstallerLib/ModTypes/RarMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/RarMod.cs
@@ -25,6 +25,8 @@ public class RarMod() : IMod
 
     private string _basePath = "";
     
+    private bool _isInstalled = false;
+    
     private RarArchiveEntry? GetEntry(RarArchive rarFile, string path)
     {
         var isDirectory = path.EndsWith('/');
@@ -102,6 +104,10 @@ public class RarMod() : IMod
     public Validation GetValidation() => _validation;
 
     public string GetBasePath() => _basePath;
+    
+    public bool IsInstalled() => _isInstalled;
+    
+    public void SetInstalled(bool installed) => _isInstalled = installed;
 
     public string GetId()
     {

--- a/ModsOfMistriaInstallerLib/ModTypes/ZipMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/ZipMod.cs
@@ -24,6 +24,8 @@ public class ZipMod() : IMod
     private ZipArchive? _zipFile;
 
     private string _basePath = "";
+    
+    private bool _isInstalled = false;
 
     public ZipMod(ZipArchive zipFile, string basePath) : this()
     {
@@ -87,6 +89,10 @@ public class ZipMod() : IMod
     public Validation GetValidation() => _validation;
 
     public string GetBasePath() => _basePath;
+    
+    public bool IsInstalled() => _isInstalled;
+    
+    public void SetInstalled(bool installed) => _isInstalled = installed;
 
     public string GetId()
     {

--- a/ModsOfMistriaInstallerLib/Standalone.cs
+++ b/ModsOfMistriaInstallerLib/Standalone.cs
@@ -32,7 +32,7 @@ public static class Standalone
         
         var installer = new ModInstaller(mistriaLocation, modsLocation);
 
-        var allMods = MistriaLocator.GetMods(modsLocation);
+        var allMods = MistriaLocator.GetMods(mistriaLocation, modsLocation);
         installer.ValidateMods(allMods);
         
         allMods = allMods

--- a/ModsOfMistriaInstallerLibTests/Fixtures/MockMod.cs
+++ b/ModsOfMistriaInstallerLibTests/Fixtures/MockMod.cs
@@ -80,6 +80,16 @@ public class MockMod : IMod
         throw new NotImplementedException();
     }
 
+    public bool IsInstalled()
+    {
+        throw new NotImplementedException();
+    }
+    
+    public void SetInstalled(bool installed)
+    {
+        throw new NotImplementedException();
+    }
+
     public bool HasFilesInFolder(string folder, string extension)
     {
         throw new NotImplementedException();


### PR DESCRIPTION
This MR records the list of mods installed to the `checksums.json` file with the following format:


```json
{
  "mist": 18495436,
  "fiddle": 9544518,
  "t2_input": 1031123,
  "t2_output": 80470655,
  "localization": 3901245,
  "mods_installed": true,
  "graphics_mods": true,
  "dll_mods": true,
  "fiddle_mods": true,
  "t2_mods": true,
  "cutscene_mods": false,
  "other_mods": true,
  "mods": [
    {
      "id": "mrsfox.cute_hats_2.0",
      "name": "Cute Hats 2.0",
      "author": "MrsFox",
      "version": "2.0",
      "graphics": true,
      "dll": false,
      "fiddle": true,
      "t2": true,
      "cutscenes": false,
      "other": true
    },
    {
      "id": "annanomoly.directional_attacks",
      "name": "Directional Attacks",
      "author": "annanomoly",
      "version": "1.0.0",
      "graphics": false,
      "dll": true,
      "fiddle": false,
      "t2": false,
      "cutscenes": false,
      "other": false
    }
  ]
}
```

The key bits of information is that we'll have

```
{
  // This will always be true. If there are no mods installed, this will not be present
  "mods_installed": true,
  
  // This will be true if any mod writes any changes to the graphics in `data.win`
  "graphics_mods": boolean,
  
  // This will be true if any mod adds DLL files to be loaded by Aurie
  "dll_mods": boolean,
  
  // This will be true if any mod modified the __fiddle__.json file
  "fiddle_mods": boolean,
  
  // This will be true if any mod modifies the `t2_output.json` file
  "t2_mods": boolean,
  
  // This will be true if any mod modified the `__mist__.json` file
  "cutscene_mods": boolean,
  
  // This will be true if any mod includes any other modifications (Outlines, Room Points etc...)
  "other_mods": boolean,
  
  // This will be a list of mods installed
  "mods": [
    // This will the ID of the mod
    "id": string,
    
    // A user-friendly name of the mod
    "name": string,
    
    // The author of the mod
    "author": string,
    
    // The mod version
    "version": string,
    
    // These all function the same as above, but are specific to this mod
    "graphics": boolean,
    "dll": boolean,
    "fiddle": boolean,
    "t2": boolean,
    "cutscenes": boolean,
    "other": boolean
  ]
}
```

Only if mods are installed. If there are no mods installed, these will be removed