### PR TITLE
Fix the sub-categories for the back accessory

### DIFF
--- a/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
+++ b/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.6.2</AssemblyVersion>
-        <FileVersion>0.6.2</FileVersion>
+        <AssemblyVersion>0.6.3</AssemblyVersion>
+        <FileVersion>0.6.3</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller-cli</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaCommandLine</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
+++ b/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.6.2</AssemblyVersion>
-        <FileVersion>0.6.2</FileVersion>
+        <AssemblyVersion>0.6.3</AssemblyVersion>
+        <FileVersion>0.6.3</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaGUI</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaInstallerLib/Models/Outfit.cs
+++ b/ModsOfMistriaInstallerLib/Models/Outfit.cs
@@ -11,7 +11,7 @@ public class Outfit
 {
     public static Dictionary<string, List<string>> ValidSlots = new()
     {
-        { "back", ["back"] },
+        { "back", ["capes", "backpacks"] },
         { "facial_hair", ["facial_hair"] },
         { "top", ["dress", "robe", "top_misc", "suit", "long_sleeve", "sleeveless", "short_sleeve"] },
         { "eyes", ["eyes" ] },

--- a/ModsOfMistriaInstallerLibTests/Models/OutfitTest.cs
+++ b/ModsOfMistriaInstallerLibTests/Models/OutfitTest.cs
@@ -32,13 +32,13 @@ public class OutfitTest
             Description = "Outfit Description",
             DefaultUnlocked = false,
             UiSlot = "back",
-            UiSubCategory = "back",
+            UiSubCategory = "backpacks",
             LutFile = "images/lut.png",
             UiItem = "images/ui.png",
             OutlineFile = "images/outline.png",
             AnimationFiles = new Dictionary<string, string>
             {
-                { "back", "images/animation" },
+                { "backpacks", "images/animation" },
             }
         };
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ in their own folder, separate from other sprites. Here's an example file:
     "description": "A dolphins tale.",
     "ui_slot": "back",
     "default_unlocked": true,
-    "ui_sub_category": "back",
+    "ui_sub_category": "capes",
     "lutFile": "images/lut.png",
     "uiItem": "images/ui.png",
     "outlineFile": "images/outline.png",


### PR DESCRIPTION
With the July update of Fields of Mistria, the allowable subcategories for the `back` slot are now `backpacks` and `capes`