### PR TITLE
Allow `target_selections` to now also work on existing store categories (#81)

### DIFF
--- a/ModsOfMistriaInstallerLib/Installer/StoreInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/StoreInstaller.cs
@@ -25,17 +25,27 @@ public class StoreInstaller : ISubModuleInstaller
                 throw new Exception(
                     $"Could not add category {iconName} to {storeName} because {storeName} does not exist");
 
-            if (categories.Any(existingCategory => existingCategory["icon"]?.ToString() == iconName))
+            var existingCategory = categories
+                .FirstOrDefault(existingCategory => existingCategory["icon"]?.ToString() == iconName);
+
+            if (existingCategory is not null)
+            {
+                if (category.TargetSelections is null) return;
+
+                existingCategory["target_selections"] = category.TargetSelections;
+                existingCategory["random_stock"] ??= new JArray();
+
                 return;
+            }
 
             var newCategory = new JObject
             {
                 { "icon", iconName }
             };
             
-            if (category.RandomSelections is not null || category.TargetSelections is not null)
+            if (category.TargetSelections is not null)
             {
-                newCategory["target_selections"] = category.TargetSelections ?? category.RandomSelections;
+                newCategory["target_selections"] = category.TargetSelections;
                 newCategory["random_stock"] = new JArray();
             }
             

--- a/ModsOfMistriaInstallerLib/Models/StoreCategory.cs
+++ b/ModsOfMistriaInstallerLib/Models/StoreCategory.cs
@@ -14,14 +14,18 @@ public class StoreCategory
     public string Store;
 
     public string Sprite;
-
-    public int? RandomSelections;
-
+    
     public int? TargetSelections;
-
+    
     [JsonIgnore] public string ModName;
     [JsonIgnore] public string FileName;
 
+    [JsonProperty("random_selections")]
+    public int? LegacyRandomSelections
+    {
+        set => TargetSelections = value;
+    }
+    
     public Validation Validate(Validation validation, IMod mod, string file)
     {
         if (string.IsNullOrWhiteSpace(Store))

--- a/ModsOfMistriaInstallerLibTests/EndToEnd/StoresTest.cs
+++ b/ModsOfMistriaInstallerLibTests/EndToEnd/StoresTest.cs
@@ -1,0 +1,672 @@
+﻿using Garethp.ModsOfMistriaInstallerLib.Generator;
+using Garethp.ModsOfMistriaInstallerLib.Installer;
+using Garethp.ModsOfMistriaInstallerLib.Installer.UMT;
+using ModsOfMistriaInstallerLibTests.Fixtures;
+using ModsOfMistriaInstallerLibTests.TestUtils;
+using Newtonsoft.Json.Linq;
+
+namespace ModsOfMistriaInstallerLibTests.EndToEnd;
+
+[TestFixture]
+public class StoresTest
+{
+    private MockInstaller _installer = new MockInstaller(
+        [new StoreGenerator()],
+        [new FiddleInstaller()]
+    );
+
+    private MockFileModifier _fileModifier;
+
+    [SetUp]
+    public void Setup()
+    {
+        _fileModifier = new MockFileModifier(new Dictionary<string, string>
+        {
+            { "__fiddle__.json", new JObject
+            {
+                { "stores", new JObject
+                {
+                    { "general", new JObject
+                    {
+                        { "name", "general" },
+                        { "categories", new JArray
+                        {
+                            new JObject
+                            {
+                                { "icon", "existing" },
+                                { "constant_stock", new JArray() }
+                            }
+                        } }
+                    } }
+                }}
+            }.ToString() }
+        });
+    }
+    
+    [Test]
+    public void ShouldAllowAddingNewCategories()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "new_icon" },
+                        { "sprite", "new_icon" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "new_icon" }
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldAddNewCategorySprites()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "new_icon" },
+                        { "sprite", "images/sprite.png" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        var information = _installer.InstallMods([mod], _fileModifier);
+
+        Assert.That(information.Sprites, Contains.Key(mod.GetId()));
+        Assert.That(
+            information.Sprites[mod.GetId()],
+            Has.Some.Matches((SpriteData sprite) =>
+                sprite is
+                {
+                    Name: "new_icon",
+                    Location: "images/sprite.png",
+                    IsUiSprite: true
+                }
+            )
+        );
+    }
+
+    [Test]
+    public void ShouldCheckStoreExistsWhenAddingNewCategories()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "non-existing" },
+                        { "icon_name", "new_icon" },
+                        { "sprite", "new_icon" }
+                    }
+                } }
+            }.ToString()}
+        });
+        
+        var exception = Assert.Throws<Exception>(() => _installer.InstallMods([mod], _fileModifier));
+        Assert.That(exception.Message, Contains.Substring("Could not add category new_icon to non-existing because non-existing does not exist"));
+    }
+
+    [Test]
+    public void ShouldSetTargetSelectionsForNewCategory()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "new_icon" },
+                        { "sprite", "images/sprite.png" },
+                        { "target_selections", 5 }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "new_icon" },
+                            { "target_selections", 5 },
+                            { "random_stock", new JArray() }
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldSetTargetSelectionsForExistingCategory()
+    {
+        _fileModifier = new MockFileModifier(new Dictionary<string, string>
+        {
+            { "__fiddle__.json", new JObject
+            {
+                { "stores", new JObject
+                {
+                    { "general", new JObject
+                    {
+                        { "name", "general" },
+                        { "categories", new JArray
+                        {
+                            new JObject
+                            {
+                                { "icon", "existing" }
+                            }
+                        } }
+                    } }
+                }}
+            }.ToString() }
+        });
+        
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "existing" },
+                        { "sprite", "images/sprite.png" },
+                        { "target_selections", 5 }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "target_selections", 5 },
+                            { "random_stock", new JArray() }
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldAcceptLegacyRandomSelectionsKey()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "new_icon" },
+                        { "sprite", "images/sprite.png" },
+                        { "random_selections", 5 }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "new_icon" },
+                            { "target_selections", 5 },
+                            { "random_stock", new JArray() }
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldAllowAddingItemsToStoreCategory()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "constant_stock", new JArray
+                            {
+                                new JObject { { "item", "seed_turnip" } }
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldCheckStoreExistsWhenAddingNewItems()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "non-existing" },
+                        { "category", "existing" }
+                    }
+                } }
+            }.ToString()}
+        });
+        
+        var exception = Assert.Throws<Exception>(() => _installer.InstallMods([mod], _fileModifier));
+        Assert.That(exception.Message, Does.StartWith("Failed adding item to the non-existing existing category because non-existing does not exist"));
+    }
+
+    [Test]
+    public void ShouldCheckCategoryExistsWhenAddingNewItems()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "non-existing" }
+                    }
+                } }
+            }.ToString()}
+        });
+        
+        var exception = Assert.Throws<Exception>(() => _installer.InstallMods([mod], _fileModifier));
+        Assert.That(exception.Message, Does.StartWith("Failed adding item to the general non-existing category because non-existing does not exist"));
+
+    }
+
+    [Test]
+    public void ShouldAllowAddingItemToRandomStock()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" },
+                        { "random_stock", true }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "random_stock", new JArray
+                            {
+                                new JObject { { "item", "seed_turnip" } }
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldEnsureRandomStockWhenAddingRandomStockItem()
+    {
+        _fileModifier = new MockFileModifier(new Dictionary<string, string>
+        {
+            { "__fiddle__.json", new JObject
+            {
+                { "stores", new JObject
+                {
+                    { "general", new JObject
+                    {
+                        { "name", "general" },
+                        { "categories", new JArray
+                        {
+                            new JObject
+                            {
+                                { "icon", "existing" }
+                            }
+                        } }
+                    } }
+                }}
+            }.ToString() }
+        });
+        
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" },
+                        { "random_stock", true }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "random_stock", new JArray
+                            {
+                                new JObject { { "item", "seed_turnip" } }
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldAddNonSeasonalItemsToConstantStock()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "constant_stock", new JArray
+                            {
+                                new JObject { { "item", "seed_turnip" } }
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [TestCase("spring")]
+    [TestCase("summer")]
+    [TestCase("fall")]
+    [TestCase("winter")]
+    public void ShouldAllowAddingSeasonalStockItems(string season)
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" },
+                        { "season", season }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "seasonal", new JObject
+                            {
+                                { season, new JArray
+                                {
+                                    new JObject { { "item", "seed_turnip" } }
+                                }}
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+
+    [Test]
+    public void ShouldEnsureSeasonsWhenAddingSeasonalItems()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" },
+                        { "season", "spring" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "seasonal", new JObject
+                            {
+                                { "spring", new JArray() },
+                                { "summer", new JArray() },
+                                { "fall", new JArray() },
+                                { "winter", new JArray() }
+                            }}
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
+    
+    [Test]
+    public void ShouldCheckSeasonExistsWhenAddingSeasonalItems()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "items", new JArray
+                {
+                    new JObject
+                    {
+                        { "item", "seed_turnip" },
+                        { "store", "general" },
+                        { "category", "existing" },
+                        { "season", "not-a-season" }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        var exception = Assert.Throws<Exception>(delegate { _installer.InstallMods([mod], _fileModifier); });
+        Assert.That(exception.Message, Is.EqualTo("Season not-a-season does not exist in general existing"));
+    }
+}

--- a/ModsOfMistriaInstallerLibTests/EndToEnd/StoresTest.cs
+++ b/ModsOfMistriaInstallerLibTests/EndToEnd/StoresTest.cs
@@ -250,6 +250,78 @@ public class StoresTest
         
         Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
     }
+    
+    [Test]
+    public void ShouldNotReplaceRandomStockWhenSettingTargetSelectionsOnExistingCategory()
+    {
+        _fileModifier = new MockFileModifier(new Dictionary<string, string>
+        {
+            { "__fiddle__.json", new JObject
+            {
+                { "stores", new JObject
+                {
+                    { "general", new JObject
+                    {
+                        { "name", "general" },
+                        { "categories", new JArray
+                        {
+                            new JObject
+                            {
+                                { "icon", "existing" },
+                                { "random_stock", new JArray
+                                {
+                                    new JObject { { "item", "turnip_seed" } }
+                                }}
+                            }
+                        } }
+                    } }
+                }}
+            }.ToString() }
+        });
+        
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            { "stores/store.json", new JObject
+            {
+                { "categories", new JArray
+                {
+                    new JObject
+                    {
+                        { "store", "general" },
+                        { "icon_name", "existing" },
+                        { "sprite", "images/sprite.png" },
+                        { "target_selections", 5 }
+                    }
+                } }
+            }.ToString()}
+        });
+
+        _installer.InstallMods([mod], _fileModifier);
+
+        var expected = new JObject
+        {
+            { "stores", new JObject
+            {
+                { "general", new JObject
+                {
+                    { "categories", new JArray
+                    {
+                        new JObject
+                        {
+                            { "icon", "existing" },
+                            { "target_selections", 5 },
+                            { "random_stock", new JArray
+                            {
+                                new JObject { { "item", "turnip_seed" } }
+                            } }
+                        }
+                    }}
+                }}
+            }}
+        };
+        
+        Assert.That(_fileModifier.GetFile("__fiddle__.json"), new ContainsJsonConstraint(expected));
+    }
 
     [Test]
     public void ShouldAcceptLegacyRandomSelectionsKey()

--- a/ModsOfMistriaInstallerLibTests/Models/StoreCategoryTest.cs
+++ b/ModsOfMistriaInstallerLibTests/Models/StoreCategoryTest.cs
@@ -94,4 +94,13 @@ public class StoreCategoryTest
 
         Assert.That(validation, Is.EqualTo(expectedValidation).Using(new ValidationComparer()));
     }
+
+    [Test]
+    public void ShouldSetTargetSelectionsFromLegacyRandomSelections()
+    {
+        var category = GetMockItem();
+        category.LegacyRandomSelections = 5;
+        
+        Assert.That(category.TargetSelections, Is.EqualTo(5));
+    }
 }


### PR DESCRIPTION
Allow `target_selections` to now also work on existing store categories (#81)