### PR TITLE
Image installer refactor

### DIFF
--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -1,7 +1,9 @@
 using Garethp.ModsOfMistriaInstallerLib.Collector;
+using Garethp.ModsOfMistriaInstallerLib.Models;
 using Garethp.ModsOfMistriaInstallerLib.ModTypes;
 using Garethp.ModsOfMistriaInstallerLib.Utils;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 using Tomlyn;
 using Tomlyn.Model;
 
@@ -102,19 +104,16 @@ public class ImageInstaller(
                 continue;
             }
 
-            var gameMeta = TomlSerializer.Deserialize<TomlTable>(fileModifier.Read(gameMetaPath));
+            var gameMeta = TomlSerializer.Deserialize<SpriteMetaFile>(fileModifier.Read(gameMetaPath));
 
-            if (!TryReadAnimationMeta(gameMeta, out var atlasType, out var frameWidth,
-                    out var frameHeight, out var frameCount))
+            if (gameMeta?.Asset is null)
             {
                 reportStatus($"Skipping replacement {spriteName}: couldn't read game animation metadata.", "");
                 continue;
             }
-            if (frameCount <= 0) frameCount = 1; // frame_len omitted = single frame
+            if (gameMeta.Asset.FrameCount <= 0) gameMeta.Asset.FrameCount = 1; // frame_len omitted = single frame
 
-            if (!gameMeta.TryGetValue("meta_properties", out var gmpObj) || gmpObj is not TomlTable gmp ||
-                !gmp.TryGetValue("id", out var idObj) || idObj is not string replaceId ||
-                string.IsNullOrEmpty(replaceId))
+            if (string.IsNullOrEmpty(gameMeta.Meta?.Id))
             {
                 reportStatus($"Skipping replacement {spriteName}: game meta has no id field.", "");
                 continue;
@@ -126,22 +125,8 @@ public class ImageInstaller(
             var modMetaRelPath = $"images/replace/{spriteName}.meta.toml";
             if (mod.FileExists(modMetaRelPath))
             {
-                var modMeta = Toml.ParseToml(mod.ReadFile(modMetaRelPath));
-
-                if (TryReadAnimationMeta(modMeta, out var oAtlas, out var oW, out var oH, out var oCount))
-                {
-                    if (!string.IsNullOrEmpty(oAtlas)) atlasType   = oAtlas;
-                    if (oW     > 0)                    frameWidth  = oW;
-                    if (oH     > 0)                    frameHeight = oH;
-                    if (oCount > 0)                    frameCount  = oCount;
-                }
-
-                if (modMeta.TryGetValue("meta_properties", out var mmpObj) && mmpObj is TomlTable mmp &&
-                    mmp.TryGetValue("replace_id", out var repObj) && repObj is string overrideId &&
-                    !string.IsNullOrEmpty(overrideId))
-                {
-                    replaceId = overrideId;
-                }
+                var modMeta = TomlSerializer.Deserialize<SpriteMetaFile>(mod.ReadFile(modMetaRelPath));
+                gameMeta.Merge(modMeta);
             }
 
             atlasType = Atlas.CanonicalType(atlasType);
@@ -155,42 +140,40 @@ public class ImageInstaller(
             }
 
             var pngInfo = Image.Identify(new MemoryStream(pngBytes));
-            if (pngInfo.Width != frameWidth * frameCount || pngInfo.Height != frameHeight)
+            if (pngInfo.Width != gameMeta.Asset.FrameWidth * gameMeta.Asset.FrameCount || pngInfo.Height != gameMeta.Asset.FrameHeight)
             {
-                if (pngInfo.Width % frameCount != 0)
+                if (pngInfo.Width % gameMeta.Asset.FrameCount != 0)
                 {
                     reportStatus($"Skipping replacement {spriteName}: image width {pngInfo.Width} " +
-                                 $"is not divisible by frame count {frameCount}.", "");
+                                 $"is not divisible by frame count {gameMeta.Asset.FrameCount}.", "");
                     continue;
                 }
 
-                frameWidth  = pngInfo.Width / frameCount;
-                frameHeight = pngInfo.Height;
+                gameMeta.Asset.FrameWidth  = pngInfo.Width / gameMeta.Asset.FrameCount;
+                gameMeta.Asset.FrameHeight = pngInfo.Height;
 
-                UpdateGameMetaDimensions(gameMeta, gameMetaPath, frameWidth, frameHeight, frameCount);
-                reportStatus($"{spriteName}: resized to {frameWidth}×{frameHeight} ({frameCount} frame(s))", "");
+                UpdateGameMetaDimensions(gameMeta, gameMetaPath);
+                reportStatus($"{spriteName}: resized to {gameMeta.Asset.FrameWidth}×{gameMeta.Asset.FrameHeight} ({gameMeta.Asset.FrameCount} frame(s))", "");
             }
 
-            FileNameUIDMapping[baseName] = replaceId;
-            IDManager.RegisterId(replaceId);
-            atlasUtils.RemoveById(replaceId);
+            FileNameUIDMapping[baseName] = gameMeta.Meta.Id;
+            IDManager.RegisterId(gameMeta.Meta.Id);
+            atlasUtils.RemoveById(gameMeta.Meta.Id);
 
             using var pngStream = new MemoryStream(pngBytes);
-            var id = atlasUtils.AddStrip(atlasType, frameWidth, frameHeight, frameCount,
+            var id = atlasUtils.AddStrip(gameMeta.Asset.Atlas!, gameMeta.Asset.FrameWidth, gameMeta.Asset.FrameHeight, gameMeta.Asset.FrameCount,
                 pngStream, FileNameUIDMapping, baseName);
 
-            reportStatus($"Replaced {spriteName} → {atlasType} atlas (id {id})", "");
+            reportStatus($"Replaced {spriteName} → {gameMeta.Asset.Atlas} atlas (id {id})", "");
         }
     }
-
-    private void UpdateGameMetaDimensions(
-        TomlTable gameMeta, string gameMetaPath, int frameWidth, int frameHeight, int frameCount)
+    
+    private void UpdateGameMetaDimensions(SpriteMetaFile gameMeta, string gameMetaPath)
     {
-        if (!gameMeta.TryGetValue("asset_properties", out var apObj) || apObj is not TomlTable ap)
+        if (gameMeta.Asset is null)
             return;
 
-        ap["frame_size"] = new TomlArray { frameWidth, frameHeight };
-        ap["dimensions"] = new TomlArray { frameWidth * frameCount, frameHeight };
+        gameMeta.Asset.Dimensions = [gameMeta.Asset.FrameWidth * gameMeta.Asset.FrameCount, gameMeta.Asset.FrameHeight];
 
         fileModifier.Write(gameMetaPath, TomlSerializer.Serialize(gameMeta));
     }

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -49,8 +49,8 @@ public class ImageInstaller(
                 continue;
             }
             if (metaToml.Asset.FrameCount is null or <= 0) metaToml.Asset.FrameCount = 1; // frame_len omitted = single frame
-            metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas ?? "");
-            
+            metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas);
+
             if (metaToml.Meta is not null)
             {
                 // replace_id: reuse an existing game texture_id and remove the old atlas entries.
@@ -129,8 +129,8 @@ public class ImageInstaller(
                 var modMeta = TomlSerializer.Deserialize<SpriteMetaFile>(mod.ReadFile(modMetaRelPath));
                 gameMeta.Merge(modMeta);
             }
-
-            gameMeta.Asset.Atlas = Atlas.CanonicalType(gameMeta.Asset.Atlas ?? "");
+            
+            gameMeta.Asset.Atlas = Atlas.CanonicalType(gameMeta.Asset.Atlas);
 
             byte[] pngBytes;
             using (var src = mod.ReadFileAsStream(pngPath))

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -158,9 +158,10 @@ public class ImageInstaller(
             }
 
             fileModifier.Write(gameMetaPath, TomlSerializer.Serialize(gameMeta));
-            FileNameUIDMapping[baseName] = gameMeta.Meta.Id;
-            IDManager.RegisterId(gameMeta.Meta.Id);
-            atlasUtils.RemoveById(gameMeta.Meta.Id);
+            
+            FileNameUIDMapping[baseName] = gameMeta.Meta.ReplaceId ?? gameMeta.Meta.Id;
+            IDManager.RegisterId(gameMeta.Meta.ReplaceId ?? gameMeta.Meta.Id);
+            atlasUtils.RemoveById(gameMeta.Meta.ReplaceId ?? gameMeta.Meta.Id);
 
             using var pngStream = new MemoryStream(pngBytes);
             var id = atlasUtils.AddStrip(

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -3,9 +3,7 @@ using Garethp.ModsOfMistriaInstallerLib.Models;
 using Garethp.ModsOfMistriaInstallerLib.ModTypes;
 using Garethp.ModsOfMistriaInstallerLib.Utils;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Processing;
 using Tomlyn;
-using Tomlyn.Model;
 
 namespace Garethp.ModsOfMistriaInstallerLib.Installer;
 
@@ -50,7 +48,7 @@ public class ImageInstaller(
                 reportStatus($"Skipping {group.BaseName}: missing animation metadata.", "");
                 continue;
             }
-            if (metaToml.Asset.FrameCount <= 0) metaToml.Asset.FrameCount = 1; // frame_len omitted = single frame
+            if (metaToml.Asset.FrameCount is null or <= 0) metaToml.Asset.FrameCount = 1; // frame_len omitted = single frame
             metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas);
             
             if (metaToml.Meta is not null)
@@ -76,7 +74,7 @@ public class ImageInstaller(
                 metaToml.Asset.Atlas, 
                 metaToml.Asset.FrameWidth, 
                 metaToml.Asset.FrameHeight, 
-                metaToml.Asset.FrameCount, 
+                metaToml.Asset.FrameCount ?? 1, 
                 pngStream, 
                 FileNameUIDMapping, 
                 group.BaseName
@@ -114,7 +112,7 @@ public class ImageInstaller(
                 reportStatus($"Skipping replacement {spriteName}: couldn't read game animation metadata.", "");
                 continue;
             }
-            if (gameMeta.Asset.FrameCount <= 0) gameMeta.Asset.FrameCount = 1; // frame_len omitted = single frame
+            if (gameMeta.Asset.FrameCount is null or <= 0) gameMeta.Asset.FrameCount = 1; // frame_len omitted = single frame
 
             if (string.IsNullOrEmpty(gameMeta.Meta?.Id))
             {
@@ -152,10 +150,10 @@ public class ImageInstaller(
                     continue;
                 }
 
-                gameMeta.Asset.FrameWidth  = pngInfo.Width / gameMeta.Asset.FrameCount;
+                gameMeta.Asset.FrameWidth  = pngInfo.Width / (gameMeta.Asset.FrameCount ?? 1);
                 gameMeta.Asset.FrameHeight = pngInfo.Height;
 
-                gameMeta.Asset.Dimensions = [gameMeta.Asset.FrameWidth * gameMeta.Asset.FrameCount, gameMeta.Asset.FrameHeight];
+                gameMeta.Asset.Dimensions = [gameMeta.Asset.FrameWidth * (gameMeta.Asset.FrameCount ?? 1), gameMeta.Asset.FrameHeight];
                 reportStatus($"{spriteName}: resized to {gameMeta.Asset.FrameWidth}×{gameMeta.Asset.FrameHeight} ({gameMeta.Asset.FrameCount} frame(s))", "");
             }
 
@@ -165,8 +163,15 @@ public class ImageInstaller(
             atlasUtils.RemoveById(gameMeta.Meta.Id);
 
             using var pngStream = new MemoryStream(pngBytes);
-            var id = atlasUtils.AddStrip(gameMeta.Asset.Atlas!, gameMeta.Asset.FrameWidth, gameMeta.Asset.FrameHeight, gameMeta.Asset.FrameCount,
-                pngStream, FileNameUIDMapping, baseName);
+            var id = atlasUtils.AddStrip(
+                gameMeta.Asset.Atlas!, 
+                gameMeta.Asset.FrameWidth, 
+                gameMeta.Asset.FrameHeight, 
+                gameMeta.Asset.FrameCount ?? 1,
+                pngStream, 
+                FileNameUIDMapping, 
+                baseName
+            );
 
             reportStatus($"Replaced {spriteName} → {gameMeta.Asset.Atlas} atlas (id {id})", "");
         }
@@ -184,37 +189,4 @@ public class ImageInstaller(
     private static bool IsUnderReplaceFolder(string relPath) =>
         relPath.Replace('\\', '/').Contains("/replace/", StringComparison.OrdinalIgnoreCase) ||
         relPath.StartsWith("replace/", StringComparison.OrdinalIgnoreCase);
-
-    // ── Shared helpers ────────────────────────────────────────────────────────────
-
-    private static bool TryReadAnimationMeta(
-        TomlTable meta,
-        out string atlasType,
-        out int frameWidth,
-        out int frameHeight,
-        out int frameCount)
-    {
-        atlasType   = "";
-        frameWidth  = 0;
-        frameHeight = 0;
-        frameCount  = 0;
-
-        if (!meta.TryGetValue("asset_properties", out var apObj) ||
-            apObj is not TomlTable ap) return false;
-
-        if (ap.TryGetValue("atlas", out var atlasObj))
-            atlasType = atlasObj?.ToString() ?? "";
-
-        if (ap.TryGetValue("frame_size", out var fsObj) &&
-            fsObj is TomlArray frameSize && frameSize.Count >= 2)
-        {
-            frameWidth  = Convert.ToInt32(frameSize[0]);
-            frameHeight = Convert.ToInt32(frameSize[1]);
-        }
-
-        if (ap.TryGetValue("frame_len", out var flObj))
-            frameCount = Convert.ToInt32(flObj);
-
-        return !string.IsNullOrEmpty(atlasType) && frameWidth > 0 && frameHeight > 0;
-    }
 }

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -43,43 +43,46 @@ public class ImageInstaller(
             // Skip anything that lives inside a replace/ subfolder
             if (IsUnderReplaceFolder(group.PngRelPath!)) continue;
 
-            var metaToml = Toml.ParseToml(mod.ReadFile(group.AnimationMetaRelPath!));
+            var metaToml = TomlSerializer.Deserialize<SpriteMetaFile>(mod.ReadFile(group.AnimationMetaRelPath!))!;
 
-            if (!TryReadAnimationMeta(metaToml, out var atlasType, out var frameWidth,
-                    out var frameHeight, out var frameCount))
+            if (string.IsNullOrEmpty(metaToml.Asset?.Atlas) || metaToml.Asset.FrameWidth == 0 || metaToml.Asset.FrameHeight == 0)
             {
                 reportStatus($"Skipping {group.BaseName}: missing animation metadata.", "");
                 continue;
             }
-            if (frameCount <= 0) frameCount = 1; // frame_len omitted = single frame
-            atlasType = Atlas.CanonicalType(atlasType);
-
-            if (metaToml.TryGetValue("meta_properties", out var mpObj) && mpObj is TomlTable mp)
+            if (metaToml.Asset.FrameCount <= 0) metaToml.Asset.FrameCount = 1; // frame_len omitted = single frame
+            metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas);
+            
+            if (metaToml.Meta is not null)
             {
                 // replace_id: reuse an existing game texture_id and remove the old atlas entries.
-                if (mp.TryGetValue("replace_id", out var repObj) &&
-                    repObj is string replaceId && !string.IsNullOrEmpty(replaceId))
+                if (!string.IsNullOrEmpty(metaToml.Meta.ReplaceId))
                 {
-                    FileNameUIDMapping[group.BaseName] = replaceId;
-                    IDManager.RegisterId(replaceId);
-                    atlasUtils.RemoveById(replaceId);
-                    reportStatus($"Replacing {group.BaseName} (id {replaceId})", "");
+                    FileNameUIDMapping[group.BaseName] = metaToml.Meta.ReplaceId;
+                    IDManager.RegisterId(metaToml.Meta.ReplaceId);
+                    atlasUtils.RemoveById(metaToml.Meta.ReplaceId);
+                    reportStatus($"Replacing {group.BaseName} (id {metaToml.Meta.ReplaceId})", "");
                 }
                 // id: preset ID for a new sprite.
-                else if (mp.TryGetValue("id", out var presetIdObj) &&
-                         presetIdObj is string presetId && !string.IsNullOrEmpty(presetId) &&
-                         !FileNameUIDMapping.ContainsKey(group.BaseName))
+                else if (!string.IsNullOrEmpty(metaToml.Meta.Id) && !FileNameUIDMapping.ContainsKey(group.BaseName))
                 {
-                    FileNameUIDMapping[group.BaseName] = presetId;
-                    IDManager.RegisterId(presetId);
+                    FileNameUIDMapping[group.BaseName] = metaToml.Meta.Id;
+                    IDManager.RegisterId(metaToml.Meta.Id);
                 }
             }
 
             using var pngStream = mod.ReadFileAsStream(group.PngRelPath!);
-            var id = atlasUtils.AddStrip(atlasType, frameWidth, frameHeight, frameCount,
-                pngStream, FileNameUIDMapping, group.BaseName);
+            var id = atlasUtils.AddStrip(
+                metaToml.Asset.Atlas, 
+                metaToml.Asset.FrameWidth, 
+                metaToml.Asset.FrameHeight, 
+                metaToml.Asset.FrameCount, 
+                pngStream, 
+                FileNameUIDMapping, 
+                group.BaseName
+            );
 
-            reportStatus($"Packed {group.BaseName} → {atlasType} atlas (id {id})", "");
+            reportStatus($"Packed {group.BaseName} → {metaToml.Asset.Atlas} atlas (id {id})", "");
         }
     }
 
@@ -129,7 +132,7 @@ public class ImageInstaller(
                 gameMeta.Merge(modMeta);
             }
 
-            atlasType = Atlas.CanonicalType(atlasType);
+            gameMeta.Asset.Atlas = Atlas.CanonicalType(gameMeta.Asset.Atlas);
 
             byte[] pngBytes;
             using (var src = mod.ReadFileAsStream(pngPath))
@@ -152,10 +155,11 @@ public class ImageInstaller(
                 gameMeta.Asset.FrameWidth  = pngInfo.Width / gameMeta.Asset.FrameCount;
                 gameMeta.Asset.FrameHeight = pngInfo.Height;
 
-                UpdateGameMetaDimensions(gameMeta, gameMetaPath);
+                gameMeta.Asset.Dimensions = [gameMeta.Asset.FrameWidth * gameMeta.Asset.FrameCount, gameMeta.Asset.FrameHeight];
                 reportStatus($"{spriteName}: resized to {gameMeta.Asset.FrameWidth}×{gameMeta.Asset.FrameHeight} ({gameMeta.Asset.FrameCount} frame(s))", "");
             }
 
+            fileModifier.Write(gameMetaPath, TomlSerializer.Serialize(gameMeta));
             FileNameUIDMapping[baseName] = gameMeta.Meta.Id;
             IDManager.RegisterId(gameMeta.Meta.Id);
             atlasUtils.RemoveById(gameMeta.Meta.Id);
@@ -166,16 +170,6 @@ public class ImageInstaller(
 
             reportStatus($"Replaced {spriteName} → {gameMeta.Asset.Atlas} atlas (id {id})", "");
         }
-    }
-    
-    private void UpdateGameMetaDimensions(SpriteMetaFile gameMeta, string gameMetaPath)
-    {
-        if (gameMeta.Asset is null)
-            return;
-
-        gameMeta.Asset.Dimensions = [gameMeta.Asset.FrameWidth * gameMeta.Asset.FrameCount, gameMeta.Asset.FrameHeight];
-
-        fileModifier.Write(gameMetaPath, TomlSerializer.Serialize(gameMeta));
     }
 
     // Recursively searches assets/animations/ for a meta.toml matching the sprite name.

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -49,7 +49,7 @@ public class ImageInstaller(
                 continue;
             }
             if (metaToml.Asset.FrameCount is null or <= 0) metaToml.Asset.FrameCount = 1; // frame_len omitted = single frame
-            metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas);
+            metaToml.Asset.Atlas = Atlas.CanonicalType(metaToml.Asset.Atlas ?? "");
             
             if (metaToml.Meta is not null)
             {
@@ -130,7 +130,7 @@ public class ImageInstaller(
                 gameMeta.Merge(modMeta);
             }
 
-            gameMeta.Asset.Atlas = Atlas.CanonicalType(gameMeta.Asset.Atlas);
+            gameMeta.Asset.Atlas = Atlas.CanonicalType(gameMeta.Asset.Atlas ?? "");
 
             byte[] pngBytes;
             using (var src = mod.ReadFileAsStream(pngPath))

--- a/ModsOfMistriaInstallerLib/Installer/TOMLInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/TOMLInstaller.cs
@@ -72,7 +72,7 @@ public class TOMLInstaller(
         if (toml.TryGetValue("asset_properties", out var apObj) && apObj is TomlTable ap &&
             ap.TryGetValue("atlas", out var atlasObj) && atlasObj is string atlasName)
         {
-            ap["atlas"] = Atlas.CanonicalType(atlasName);
+            ap["atlas"] = Atlas.CanonicalType(atlasName)!;
         }
 
         MergeOrWriteToml(toml, dest);

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -42,7 +42,6 @@ public class SpriteMetaFileProperties
         if (!string.IsNullOrEmpty(newProperties.ReplaceId))
         {
             Id = newProperties.ReplaceId;
-            ReplaceId = newProperties.ReplaceId;
         }
 
         if (!string.IsNullOrEmpty(newProperties.AssetKind))
@@ -54,12 +53,14 @@ public class SpriteMetaFileAssetProperties
 {
     [TomlPropertyName("atlas")] public string? Atlas { get; set; }
 
+    [TomlIgnore]
     public int FrameWidth
     {
         get => FrameSize[0];
         set => FrameSize[0] = value;
     }
 
+    [TomlIgnore]
     public int FrameHeight
     {
         get => FrameSize[1];
@@ -72,7 +73,7 @@ public class SpriteMetaFileAssetProperties
 
     [TomlPropertyName("frame_len")] public int FrameCount { get; set; } = 0;
     
-    [TomlPropertyName("duration")] public List<float>? Duration { get; set; }
+    [TomlPropertyName("duration")] public List<double>? Duration { get; set; }
 
     [TomlPropertyName("offset")] public SpriteMetaFileAssetOffset? Offset { get; set; }
 

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -41,7 +41,7 @@ public class SpriteMetaFileProperties
 
         if (!string.IsNullOrEmpty(newProperties.ReplaceId))
         {
-            Id = newProperties.ReplaceId;
+            ReplaceId = newProperties.ReplaceId;
         }
 
         if (!string.IsNullOrEmpty(newProperties.AssetKind))

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -71,11 +71,20 @@ public class SpriteMetaFileAssetProperties
 
     [TomlPropertyName("dimensions")] public List<int>? Dimensions { get; set; }
 
-    [TomlPropertyName("frame_len")] public int FrameCount { get; set; } = 0;
+    [TomlPropertyName("frame_len")] public int? FrameCount { get; set; }
     
+    [TomlSingleOrArray]
     [TomlPropertyName("duration")] public List<double>? Duration { get; set; }
 
     [TomlPropertyName("offset")] public SpriteMetaFileAssetOffset? Offset { get; set; }
+    
+    [TomlPropertyName("filter_kind")] public string? Filter { get; set; }
+    
+    [TomlPropertyName("mipmap_filter_kind")] public string? MipmapFilter { get; set; }
+    
+    [TomlPropertyName("wrap")] public string? Wrap { get; set; }
+    
+    [TomlPropertyName("tags")] public List<string>? Tags { get; set; }
 
     public void Merge(SpriteMetaFileAssetProperties? newProperties)
     {
@@ -87,6 +96,10 @@ public class SpriteMetaFileAssetProperties
         if (newProperties.FrameHeight > 0) FrameHeight = newProperties.FrameHeight;
         if (newProperties.Duration is not null) Duration = newProperties.Duration;
         if (newProperties.Dimensions is not null) Dimensions = newProperties.Dimensions;
+        if (newProperties.Filter is not null) Filter = newProperties.Filter;
+        if (newProperties.MipmapFilter is not null) MipmapFilter = newProperties.MipmapFilter;
+        if (newProperties.Wrap is not null) Wrap = newProperties.Wrap;
+        if (newProperties.Tags is not null) Tags = newProperties.Tags;
 
         if (Offset is null)
             Offset = newProperties.Offset;

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -1,0 +1,101 @@
+﻿using Tomlyn.Serialization;
+
+namespace Garethp.ModsOfMistriaInstallerLib.Models;
+
+public class SpriteMetaFile
+{
+    [TomlPropertyName("meta_properties")] public SpriteMetaFileProperties? Meta { get; set; }
+
+    [TomlPropertyName("asset_properties")] public SpriteMetaFileAssetProperties? Asset { get; set; }
+
+    public void Merge(SpriteMetaFile? newProperties)
+    {
+        if (newProperties is null) return;
+        
+        if (Meta is null)
+            Meta = newProperties.Meta;
+        else
+            Meta.Merge(newProperties.Meta);
+
+        if (Asset is null)
+            Asset = newProperties.Asset;
+        else
+            Asset.Merge(newProperties.Asset);
+    }
+}
+
+public class SpriteMetaFileProperties
+{
+    [TomlPropertyName("id")] public string? Id { get; set; }
+    
+    [TomlPropertyName("replace_id")] public string? ReplaceId { get; set; }
+
+    [TomlPropertyName("asset_kind")] public string? AssetKind { get; set; }
+
+    public void Merge(SpriteMetaFileProperties? newProperties)
+    {
+        if (newProperties is null) return;
+        
+        if (!string.IsNullOrEmpty(newProperties.Id))
+            Id = newProperties.Id;
+
+        if (!string.IsNullOrEmpty(newProperties.AssetKind))
+            AssetKind = newProperties.AssetKind;
+    }
+}
+
+public class SpriteMetaFileAssetProperties
+{
+    [TomlPropertyName("atlas")] public string? Atlas { get; set; }
+
+    public int FrameWidth
+    {
+        get => FrameSize[0];
+        set => FrameSize[0] = value;
+    }
+
+    public int FrameHeight
+    {
+        get => FrameSize[1];
+        set => FrameSize[1] = value;
+    }
+
+    [TomlPropertyName("frame_size")] public List<int> FrameSize { get; set; } = [0, 0];
+
+    [TomlPropertyName("frame_len")] public int FrameLength { get; set; } = 0;
+    
+    [TomlPropertyName("duration")] public List<float>? Duration { get; set; }
+
+    [TomlPropertyName("offset")] public SpriteMetaFileAssetOffset? Offset { get; set; }
+
+    public void Merge(SpriteMetaFileAssetProperties? newProperties)
+    {
+        if (newProperties is null) return;
+        
+        if (!string.IsNullOrEmpty(newProperties.Atlas)) Atlas = newProperties.Atlas;
+        if (newProperties.FrameLength > 1) FrameLength = newProperties.FrameLength;
+        if (newProperties.FrameWidth > 0) FrameWidth = newProperties.FrameWidth;
+        if (newProperties.FrameHeight > 0) FrameHeight = newProperties.FrameHeight;
+        if (newProperties.Duration is not null) Duration = newProperties.Duration;
+
+        if (Offset is null)
+            Offset = newProperties.Offset;
+        else
+            Offset.Merge(newProperties.Offset);
+    }
+}
+
+public class SpriteMetaFileAssetOffset
+{
+    [TomlPropertyName("horizontal")] public object? Horizontal { get; set; }
+
+    [TomlPropertyName("vertical")] public object? Vertical { get; set; }
+
+    public void Merge(SpriteMetaFileAssetOffset? newProperties)
+    {
+        if (newProperties is null) return;
+        
+        if (newProperties.Horizontal is not null) Horizontal = newProperties.Horizontal;
+        if (newProperties.Vertical is not null) Vertical = newProperties.Vertical;
+    }
+}

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -39,6 +39,12 @@ public class SpriteMetaFileProperties
         if (!string.IsNullOrEmpty(newProperties.Id))
             Id = newProperties.Id;
 
+        if (!string.IsNullOrEmpty(newProperties.ReplaceId))
+        {
+            Id = newProperties.ReplaceId;
+            ReplaceId = newProperties.ReplaceId;
+        }
+
         if (!string.IsNullOrEmpty(newProperties.AssetKind))
             AssetKind = newProperties.AssetKind;
     }
@@ -62,7 +68,9 @@ public class SpriteMetaFileAssetProperties
 
     [TomlPropertyName("frame_size")] public List<int> FrameSize { get; set; } = [0, 0];
 
-    [TomlPropertyName("frame_len")] public int FrameLength { get; set; } = 0;
+    [TomlPropertyName("dimensions")] public List<int>? Dimensions { get; set; }
+
+    [TomlPropertyName("frame_len")] public int FrameCount { get; set; } = 0;
     
     [TomlPropertyName("duration")] public List<float>? Duration { get; set; }
 
@@ -73,10 +81,11 @@ public class SpriteMetaFileAssetProperties
         if (newProperties is null) return;
         
         if (!string.IsNullOrEmpty(newProperties.Atlas)) Atlas = newProperties.Atlas;
-        if (newProperties.FrameLength > 1) FrameLength = newProperties.FrameLength;
+        if (newProperties.FrameCount > 1) FrameCount = newProperties.FrameCount;
         if (newProperties.FrameWidth > 0) FrameWidth = newProperties.FrameWidth;
         if (newProperties.FrameHeight > 0) FrameHeight = newProperties.FrameHeight;
         if (newProperties.Duration is not null) Duration = newProperties.Duration;
+        if (newProperties.Dimensions is not null) Dimensions = newProperties.Dimensions;
 
         if (Offset is null)
             Offset = newProperties.Offset;

--- a/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
+++ b/ModsOfMistriaInstallerLib/Models/SpriteMetaFile.cs
@@ -1,4 +1,5 @@
-﻿using Tomlyn.Serialization;
+﻿using Garethp.ModsOfMistriaInstallerLib.Utils;
+using Tomlyn.Serialization;
 
 namespace Garethp.ModsOfMistriaInstallerLib.Models;
 
@@ -73,6 +74,7 @@ public class SpriteMetaFileAssetProperties
 
     [TomlPropertyName("frame_len")] public int? FrameCount { get; set; }
     
+    [TomlConverter(typeof(TomlSingleOrArrayConverter))]
     [TomlSingleOrArray]
     [TomlPropertyName("duration")] public List<double>? Duration { get; set; }
 

--- a/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
+++ b/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
@@ -42,8 +42,4 @@
       </Compile>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Models\" />
-    </ItemGroup>
-
 </Project>

--- a/ModsOfMistriaInstallerLib/Utils/Atlas.cs
+++ b/ModsOfMistriaInstallerLib/Utils/Atlas.cs
@@ -50,8 +50,12 @@ public class Atlas
     private static readonly HashSet<string> RetiredTypes =
         new(StringComparer.OrdinalIgnoreCase) { "Shadow", "Animals", "Player", "Lut" };
 
-    public static string CanonicalType(string type) =>
-        RetiredTypes.Contains(type) ? "Default" : type;
+    public static string? CanonicalType(string? type)
+    {
+        if (type is null) return null;
+        
+        return RetiredTypes.Contains(type) ? "Default" : type;
+    }
 
     private static bool IsUnnumbered(string type, int number) =>
         number == 0 && UnnumberedTypes.Contains(type);

--- a/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
+++ b/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
@@ -53,6 +53,7 @@ public class AtlasUtilities
         }
 
         using var stripImage = Image.Load<Rgba32>(pngStream);
+        pngStream.Close();
 
         for (int i = 0; i < frameCount; i++)
         {

--- a/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
+++ b/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
@@ -40,7 +40,7 @@ public class AtlasUtilities
         Dictionary<string, string> fileNameUIDMapping,
         string baseName)
     {
-        atlasType = Atlas.CanonicalType(atlasType);
+        atlasType = Atlas.CanonicalType(atlasType)!;
 
         if (!_states.TryGetValue(atlasType, out var state))
             state = OpenState(atlasType);

--- a/ModsOfMistriaInstallerLib/Utils/Toml.cs
+++ b/ModsOfMistriaInstallerLib/Utils/Toml.cs
@@ -7,4 +7,79 @@ public static class Toml
 {
     public static TomlTable ParseToml(string content) =>
         TomlSerializer.Deserialize<TomlTable>(content);
+    
+    public static bool Compare(object aObject, object bObject)
+    {
+        // This is to account for the behavior of `[TomlSingleOrArray]`
+        if (aObject is TomlArray aArray1 && bObject is not TomlArray && aArray1.Count == 1)
+            return Compare(aArray1.First(), bObject);
+        if (bObject is TomlArray bArray1 && aObject is not TomlArray && bArray1.Count == 1)
+            return Compare(aObject, bArray1.First());
+        
+        switch (aObject)
+        {
+            case TomlTable aTable:
+            {
+                if (bObject is not TomlTable bTable)
+                {
+                    return false;
+                }
+
+                if (aTable.Count != bTable.Count)
+                {
+                    return false;
+                }
+
+                foreach (var key in aTable.Keys)
+                {
+                    if (!bTable.ContainsKey(key))
+                        return false;
+
+                    if (!Compare(aTable[key], bTable[key]))
+                    {
+                        return false;
+                    }
+                }
+
+                break;
+            }
+            case string aString:
+            {
+                if (bObject is not string bString)
+                    return false;
+
+                return aString == bString;
+            }
+            case TomlArray aArray:
+            {
+                if (bObject is not TomlArray bArray)
+                    return false;
+
+                if (aArray.Count != bArray.Count)
+                    return false;
+                
+                for (var i = 0; i < aArray.Count; i++)
+                {
+                    if (!Compare(aArray[i], bArray[i]))
+                        return false;
+                }
+
+                return true;
+            }
+            case long aLong:
+                if (bObject is not long bLong)
+                    return false;
+
+                return aLong == bLong;
+            case double aDouble:
+                if (bObject is not double bDouble)
+                    return false;
+                
+                return aDouble == bDouble;
+            default:
+                return false;
+        }
+
+        return true;
+    }
 }

--- a/ModsOfMistriaInstallerLib/Utils/TomlSingleOrArrayConverter.cs
+++ b/ModsOfMistriaInstallerLib/Utils/TomlSingleOrArrayConverter.cs
@@ -1,0 +1,65 @@
+﻿using System.Runtime.CompilerServices;
+using Tomlyn.Serialization;
+
+namespace Garethp.ModsOfMistriaInstallerLib.Utils;
+
+// Fields of Mistria has some fields (SpriteMetaFileAssetProperties::Duration) that can be either a single value or a
+// list however if we then write that single value back into a list with a single value to FoM it'll cause errors reading
+// them, so we need a custom converter to make sure that if a single value came in, a single value will go back out.
+public class TomlSingleOrArrayConverter: TomlConverter
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        if (typeToConvert == typeof(double)) return true;
+        if (typeToConvert == typeof(List<double>)) return true;
+        
+        return false;
+    }
+
+    public override object? Read(TomlReader reader, Type typeToConvert)
+    {
+        switch (reader.TokenType)
+        {
+            case TomlTokenType.Float:
+                return new List<double>()
+                {
+                    reader.GetDouble()
+                };
+            case TomlTokenType.StartArray:
+                reader.Read();
+
+                var list = new List<double>();
+                while (reader.TokenType != TomlTokenType.EndArray)
+                {
+                    if (reader.TokenType != TomlTokenType.Float)
+                        throw new Exception($"Unexpected token {reader.TokenType}");
+                    
+                    list.Add(reader.GetDouble());
+                    reader.Read();
+                }
+
+                reader.Read();
+                return list;
+            default:
+                throw new Exception($"Unexpected token {reader.TokenType}");
+        }
+    }
+
+    public override void Write(TomlWriter writer, object? value)
+    {
+        if (value is not List<double> list)
+        {
+            return;
+        }
+
+        if (list.Count == 1)
+        {
+            writer.WriteFloatValue(list.First());
+            return;
+        }
+        
+        writer.WriteStartArray();
+        list.ForEach(writer.WriteFloatValue);
+        writer.WriteEndArray();
+    }
+}


### PR DESCRIPTION
This refactor of the image installer does the following:
 * Deserialises the Sprite `.meta.toml` file into a model instead of as TomlTables
 * Allows replacement images to alter all properties of the original toml file

This change does have one effect I'm not sure about. When an image has a `replace_id`, it'll write that replacement id to the games `id` field. I'm not sure if that's desirable or not.