### PR TITLE
Improve the speed of Atlas changes by just keeping data in memory once it's loaded, and only disposing of them once we're done installing

### DIFF
--- a/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
+++ b/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.12.6</AssemblyVersion>
-        <FileVersion>0.12.6</FileVersion>
+        <AssemblyVersion>0.13.0</AssemblyVersion>
+        <FileVersion>0.13.0</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller-cli</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaCommandLine</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
+++ b/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
@@ -8,8 +8,8 @@
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>
         <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-        <AssemblyVersion>0.12.6</AssemblyVersion>
-        <FileVersion>0.12.6</FileVersion>
+        <AssemblyVersion>0.13.0</AssemblyVersion>
+        <FileVersion>0.13.0</FileVersion>
         <AssemblyName>ModsOfMistriaInstaller</AssemblyName>
         <RootNamespace>Garethp.ModsOfMistriaGUI</RootNamespace>
     </PropertyGroup>

--- a/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/ImageInstaller.cs
@@ -78,8 +78,6 @@ public class ImageInstaller(
 
             reportStatus($"Packed {group.BaseName} → {atlasType} atlas (id {id})", "");
         }
-
-        atlasUtils.Flush();
     }
 
     // ── Replacement path ──────────────────────────────────────────────────────────

--- a/ModsOfMistriaInstallerLib/ModInstaller.cs
+++ b/ModsOfMistriaInstallerLib/ModInstaller.cs
@@ -67,6 +67,8 @@ public class ModInstaller
             reportStatus($"Finished {mod.GetName()}", modTimer.Elapsed.ToString());
         }
 
+        atlasUtils.Flush();
+        
         if (_fileModifier is ZipFileModifier zipFileModifier)
         {
             zipFileModifier.Close();
@@ -131,6 +133,8 @@ public class ModInstaller
         
         new FurnitureInstaller(fileNameUIDMapping, _fileModifier)
             .Install(mod, reportStatus);
+        
+        atlasUtils.SemiFlush();
     }
 
     private bool IsFreshInstall() {

--- a/ModsOfMistriaInstallerLib/Utils/Atlas.cs
+++ b/ModsOfMistriaInstallerLib/Utils/Atlas.cs
@@ -23,6 +23,10 @@ public class Atlas
     public int Width       { get; }
     public int Height      { get; }
 
+    public TomlTable? Data;
+
+    public Image<Rgba32>? Image;
+
     private IFileModifier _fileModifier;
 
     public Atlas(string type, int number, string atlasDirectory, IFileModifier fileModifier, int width = DefaultSize, int height = DefaultSize)

--- a/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
+++ b/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
@@ -60,14 +60,7 @@ public class AtlasUtilities
             {
                 // Current atlas is full — save it (if dirty) and create the next numbered one
                 int nextNumber = state.Atlas.Number + 1;
-                // if (state.IsDirty) FlushState(state);
-                // else
-                // {
-                //     state.Image.Dispose();
-                //     state.Atlas.Image?.Dispose();
-                //     state.Atlas.Image = null;
-                //     state.Atlas.Data = null;
-                // }
+                
                 _states.Remove(atlasType);
                 CreateAtlas(atlasType, nextNumber);
                 state = OpenState(atlasType);
@@ -105,21 +98,12 @@ public class AtlasUtilities
     // Must be called before AddStrip so open states don't re-introduce the old entries.
     public void RemoveById(string baseId)
     {
-        var timer = new Stopwatch();
-        timer.Start();
-        
-        var inStateTimer = new Stopwatch();
-        var allTimer = new Stopwatch();
-        var tomlTimer = new Stopwatch();
-        var diskTimer = new Stopwatch();
-        
         // Strip any ::N suffix the caller may have included
         var prefix = baseId.Contains("::") ? baseId[..baseId.IndexOf("::", StringComparison.Ordinal)] : baseId;
 
         // 1. Modify any atlas page that is already open in _states (in-memory).
         //    We collect their paths so we skip them in step 2.
         var openPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        inStateTimer.Start();
         foreach (var state in _states.Values)
         {
             openPaths.Add(state.Atlas.MetaPath);
@@ -131,13 +115,10 @@ public class AtlasUtilities
                 ClearRegion(state.Image, region);
             if (dirty || cleared.Count > 0) state.IsDirty = true;
         }
-        inStateTimer.Stop();
 
         // 2. All other atlas pages: load → prune → save (meta, and png if pixels freed).
-        allTimer.Start();
         foreach (var atlas in _atlases)
         {
-            tomlTimer.Start();
             if (openPaths.Contains(atlas.MetaPath)) continue;
             if (!_fileModifier.Exists(atlas.MetaPath)) continue;
 
@@ -153,24 +134,13 @@ public class AtlasUtilities
             bool modified = false;
             var cleared = new List<Rectangle>();
             PruneAnimations(anims, prefix, ref modified, cleared);
-            tomlTimer.Stop();
 
             if (!modified) continue;
 
             // Sanitise the freed pixel regions in the atlas image so later packs
             // can't reveal the removed art through their transparent areas.
-            diskTimer.Start();
             if (cleared.Count > 0)
             {
-                if (atlas.Type.Contains("Default"))
-                {
-                    var a = 1 + 1;
-                }
-                else
-                {
-                    var b = 1 + 1;
-                }
-                
                 if (atlas.Image is not { } image)
                 {
                     var readStream = _fileModifier.GetReadStream(atlas.PngPath);
@@ -182,19 +152,9 @@ public class AtlasUtilities
 
                 foreach (var region in cleared)
                     ClearRegion(image, region);
-
-                // var writeStream = _fileModifier.GetWriteStream(atlas.PngPath);
-                // image.Save(writeStream, image.DetectEncoder(atlas.PngPath));
-                // writeStream.Close();
             }
 
-            diskTimer.Stop();
         }
-        allTimer.Stop();
-        
-        timer.Stop();
-        // Console.WriteLine($"RemoveById took {timer.ElapsedMilliseconds}ms. Spent {tomlTimer.ElapsedMilliseconds}ms working with TOML and {diskTimer.ElapsedMilliseconds}ms on image manipulation");
-
     }
 
     // Removes or prunes animation entries that reference baseId (no ::N suffix).
@@ -361,19 +321,6 @@ public class AtlasUtilities
 
     private void FlushState(AtlasPackState state)
     {
-        // Atlases created during this session are "added" (no original to restore);
-        // pre-existing atlases are "modified" and need a backup for uninstall.
-        if (_newAtlasPaths.Contains(state.Atlas.MetaPath))
-        {
-            // _manifest.TrackAdded(state.Atlas.PngPath);
-            // _manifest.TrackAdded(state.Atlas.MetaPath);
-        }
-        else
-        {
-            // _manifest.TrackModified(state.Atlas.PngPath);
-            // _manifest.TrackModified(state.Atlas.MetaPath);
-        }
-        
         var writeStream = _fileModifier.GetWriteStream(state.Atlas.PngPath);
         state.Image.Save(writeStream, state.Image.DetectEncoder(state.Atlas.PngPath));
         writeStream.Close();

--- a/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
+++ b/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
@@ -272,9 +272,6 @@ public class AtlasUtilities
     // Writes all pending atlas changes to disk and marks them in the manifest.
     public void Flush()
     {
-        var flushTimer = new Stopwatch();
-        flushTimer.Start();
-        
         foreach (var state in _states.Values)
         {
             if (!state.IsDirty) continue;
@@ -285,6 +282,7 @@ public class AtlasUtilities
         foreach (var atlas in _atlases.Where(atlas => atlas.Data is not null))
         {
             _fileModifier.Write(atlas.MetaPath, TomlSerializer.Serialize(atlas.Data));
+            atlas.Data = null;
         }
 
         foreach (var atlas in _atlases.Where(atlas => atlas.Image is not null))
@@ -292,10 +290,22 @@ public class AtlasUtilities
             var writeStream = _fileModifier.GetWriteStream(atlas.PngPath);
             atlas.Image!.Save(writeStream, atlas.Image!.DetectEncoder(atlas.PngPath));
             writeStream.Close();
+            
+            atlas.Image.Dispose();
+            atlas.Image = null;
         }
+    }
 
-        flushTimer.Stop();
-        Console.WriteLine($"Atlas Flush took {flushTimer.ElapsedMilliseconds}ms");
+    // This is just to stop memory from running out of control if there's a large number of mods replacing or adding
+    // massive numbers of images over a large number of Atlases. We want to keep Atlases open for as long as we can,
+    // since we might need to remove items from them at any point, but we don't want to go overboard with how many
+    // we have.
+    public void SemiFlush()
+    {
+        if (_atlases.Count(atlas => atlas.Image is not null) >= 10)
+        {
+            Flush();
+        }
     }
 
     // Private helpers

--- a/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
+++ b/ModsOfMistriaInstallerLib/Utils/AtlasUtilities.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
@@ -59,8 +60,14 @@ public class AtlasUtilities
             {
                 // Current atlas is full — save it (if dirty) and create the next numbered one
                 int nextNumber = state.Atlas.Number + 1;
-                if (state.IsDirty) FlushState(state);
-                else state.Image.Dispose();
+                // if (state.IsDirty) FlushState(state);
+                // else
+                // {
+                //     state.Image.Dispose();
+                //     state.Atlas.Image?.Dispose();
+                //     state.Atlas.Image = null;
+                //     state.Atlas.Data = null;
+                // }
                 _states.Remove(atlasType);
                 CreateAtlas(atlasType, nextNumber);
                 state = OpenState(atlasType);
@@ -98,12 +105,21 @@ public class AtlasUtilities
     // Must be called before AddStrip so open states don't re-introduce the old entries.
     public void RemoveById(string baseId)
     {
+        var timer = new Stopwatch();
+        timer.Start();
+        
+        var inStateTimer = new Stopwatch();
+        var allTimer = new Stopwatch();
+        var tomlTimer = new Stopwatch();
+        var diskTimer = new Stopwatch();
+        
         // Strip any ::N suffix the caller may have included
         var prefix = baseId.Contains("::") ? baseId[..baseId.IndexOf("::", StringComparison.Ordinal)] : baseId;
 
         // 1. Modify any atlas page that is already open in _states (in-memory).
         //    We collect their paths so we skip them in step 2.
         var openPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        inStateTimer.Start();
         foreach (var state in _states.Values)
         {
             openPaths.Add(state.Atlas.MetaPath);
@@ -115,43 +131,70 @@ public class AtlasUtilities
                 ClearRegion(state.Image, region);
             if (dirty || cleared.Count > 0) state.IsDirty = true;
         }
+        inStateTimer.Stop();
 
         // 2. All other atlas pages: load → prune → save (meta, and png if pixels freed).
+        allTimer.Start();
         foreach (var atlas in _atlases)
         {
+            tomlTimer.Start();
             if (openPaths.Contains(atlas.MetaPath)) continue;
             if (!_fileModifier.Exists(atlas.MetaPath)) continue;
 
-            var data = TomlSerializer.Deserialize<TomlTable>(_fileModifier.Read(atlas.MetaPath));
+            if (atlas.Data is not { } data)
+            {
+                data = TomlSerializer.Deserialize<TomlTable>(_fileModifier.Read(atlas.MetaPath))!;
+                atlas.Data = data;
+            }
+
             if (!data.TryGetValue("asset_properties", out var apObj) || apObj is not TomlTable ap) continue;
             if (!ap.TryGetValue("animations", out var animObj) || animObj is not TomlTableArray anims) continue;
 
             bool modified = false;
             var cleared = new List<Rectangle>();
             PruneAnimations(anims, prefix, ref modified, cleared);
+            tomlTimer.Stop();
+
             if (!modified) continue;
-
-            // Backup the original before overwriting (so uninstall can restore it)
-            // _manifest.TrackModified(atlas.MetaPath);
-
-            _fileModifier.Write(atlas.MetaPath, TomlSerializer.Serialize(data));
 
             // Sanitise the freed pixel regions in the atlas image so later packs
             // can't reveal the removed art through their transparent areas.
+            diskTimer.Start();
             if (cleared.Count > 0)
             {
-                var readStream = _fileModifier.GetReadStream(atlas.PngPath);
-                using var image = Image.Load<Rgba32>(readStream);
-                readStream.Close();
+                if (atlas.Type.Contains("Default"))
+                {
+                    var a = 1 + 1;
+                }
+                else
+                {
+                    var b = 1 + 1;
+                }
+                
+                if (atlas.Image is not { } image)
+                {
+                    var readStream = _fileModifier.GetReadStream(atlas.PngPath);
+                    image = Image.Load<Rgba32>(readStream);
+                    readStream.Close();
+
+                    atlas.Image = image;
+                }
 
                 foreach (var region in cleared)
                     ClearRegion(image, region);
 
-                var writeStream = _fileModifier.GetWriteStream(atlas.PngPath);
-                image.Save(writeStream, image.DetectEncoder(atlas.PngPath));
-                writeStream.Close();
+                // var writeStream = _fileModifier.GetWriteStream(atlas.PngPath);
+                // image.Save(writeStream, image.DetectEncoder(atlas.PngPath));
+                // writeStream.Close();
             }
+
+            diskTimer.Stop();
         }
+        allTimer.Stop();
+        
+        timer.Stop();
+        // Console.WriteLine($"RemoveById took {timer.ElapsedMilliseconds}ms. Spent {tomlTimer.ElapsedMilliseconds}ms working with TOML and {diskTimer.ElapsedMilliseconds}ms on image manipulation");
+
     }
 
     // Removes or prunes animation entries that reference baseId (no ::N suffix).
@@ -229,12 +272,30 @@ public class AtlasUtilities
     // Writes all pending atlas changes to disk and marks them in the manifest.
     public void Flush()
     {
+        var flushTimer = new Stopwatch();
+        flushTimer.Start();
+        
         foreach (var state in _states.Values)
         {
             if (!state.IsDirty) continue;
             FlushState(state);
         }
         _states.Clear();
+
+        foreach (var atlas in _atlases.Where(atlas => atlas.Data is not null))
+        {
+            _fileModifier.Write(atlas.MetaPath, TomlSerializer.Serialize(atlas.Data));
+        }
+
+        foreach (var atlas in _atlases.Where(atlas => atlas.Image is not null))
+        {
+            var writeStream = _fileModifier.GetWriteStream(atlas.PngPath);
+            atlas.Image!.Save(writeStream, atlas.Image!.DetectEncoder(atlas.PngPath));
+            writeStream.Close();
+        }
+
+        flushTimer.Stop();
+        Console.WriteLine($"Atlas Flush took {flushTimer.ElapsedMilliseconds}ms");
     }
 
     // Private helpers
@@ -243,11 +304,21 @@ public class AtlasUtilities
     {
         var atlas = GetLastAtlas(atlasType);
 
-        var data  = TomlSerializer.Deserialize<TomlTable>(_fileModifier.Read(atlas.MetaPath));
-        var imageStream = _fileModifier.GetReadStream(atlas.PngPath);
-        var image = Image.Load<Rgba32>(imageStream);
-        imageStream.Close();
+        if (atlas.Data is not { } data)
+        {
+            data = TomlSerializer.Deserialize<TomlTable>(_fileModifier.Read(atlas.MetaPath));
+            atlas.Data = data;
+        }
 
+        if (atlas.Image is not { } image)
+        {
+            var imageStream = _fileModifier.GetReadStream(atlas.PngPath);
+            image = Image.Load<Rgba32>(imageStream);
+            imageStream.Close();
+            
+            atlas.Image = image;
+        }
+        
         // Safely retrieve (or create) the animations array.
         // A newly created atlas serialises an empty TomlTableArray as nothing,
         // so the key may be absent when we read it back.
@@ -299,6 +370,9 @@ public class AtlasUtilities
         
         _fileModifier.Write(state.Atlas.MetaPath, TomlSerializer.Serialize(state.Data));
         state.Image.Dispose();
+        state.Atlas.Image?.Dispose();
+        state.Atlas.Image = null;
+        state.Atlas.Data = null;
         state.IsDirty = false;
     }
 


### PR DESCRIPTION
Improve the speed of Atlas changes by just keeping data in memory once it's loaded, and only disposing of them once we're done installing