### PR TITLE
Add declarative GML patch support

### DIFF
--- a/ModsOfMistriaInstallerLib/Installer/GMLPatchInstaller.cs
+++ b/ModsOfMistriaInstallerLib/Installer/GMLPatchInstaller.cs
@@ -1,0 +1,313 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Garethp.ModsOfMistriaInstallerLib.ModTypes;
+using Garethp.ModsOfMistriaInstallerLib.Utils;
+
+namespace Garethp.ModsOfMistriaInstallerLib.Installer;
+
+/// <summary>
+/// Applies manifest-declared, exact-text patches to existing GML sources.
+/// All patches for a mod are prepared in memory before any target is written.
+/// </summary>
+public sealed class GMLPatchInstaller(
+    Dictionary<string, string> fileNameUidMapping,
+    IFileModifier fileModifier)
+    : Installer(fileNameUidMapping)
+{
+    private static readonly Regex ValidPatchId = new(
+        "^[A-Za-z0-9._-]+$",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled);
+
+    public override void Install(IMod mod, Action<string, string> reportStatus)
+    {
+        var definitions = mod.GetGmlPatches();
+        if (definitions.Count == 0) return;
+
+        var patches = PreparePatches(mod, definitions);
+        var targets = LoadTargets(patches);
+
+        // Apply in manifest order so a later patch can deliberately anchor to
+        // text introduced by an earlier patch in the same target.
+        foreach (var patch in patches)
+        {
+            var target = targets[patch.Target];
+
+            if (ContainsMarker(target.Content, patch.BeginMarker) ||
+                ContainsMarker(target.Content, patch.EndMarker))
+            {
+                throw new InvalidOperationException(
+                    $"GML patch '{patch.Definition.Id}' is already present in '{patch.Target}'.");
+            }
+
+            var matches = FindMatches(target.Content, patch.Anchor);
+            if (matches.Count != patch.Definition.ExpectedMatches)
+            {
+                throw new InvalidOperationException(
+                    $"GML patch '{patch.Definition.Id}' expected " +
+                    $"{patch.Definition.ExpectedMatches} exact anchor match(es) in '{patch.Target}', " +
+                    $"but found {matches.Count}. No GML files were changed.");
+            }
+
+            target.Content = ApplyPatch(target.Content, patch, matches);
+        }
+
+        // No validation or matching remains after this point. Each target is
+        // committed exactly once, even when it has several sequential patches.
+        foreach (var target in targets.Values)
+            fileModifier.Write(target.Destination, RestoreNewLines(target.Content, target.NewLine));
+
+        foreach (var patch in patches)
+            reportStatus($"Applied GML patch {patch.Definition.Id}: {patch.Target}", "");
+    }
+
+    private static List<PreparedPatch> PreparePatches(
+        IMod mod,
+        IReadOnlyCollection<GmlPatchDefinition> definitions)
+    {
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var patches = new List<PreparedPatch>(definitions.Count);
+
+        foreach (var definition in definitions)
+        {
+            ValidatePatchId(definition.Id);
+            if (!ids.Add(definition.Id))
+            {
+                throw new InvalidDataException(
+                    $"Duplicate GML patch id '{definition.Id}' in mod '{mod.GetId()}'.");
+            }
+
+            if (definition.Operation is not ("insert_after" or "insert_before" or "replace_exact"))
+            {
+                throw new InvalidDataException(
+                    $"GML patch '{definition.Id}' has unsupported operation '{definition.Operation}'.");
+            }
+
+            if (definition.ExpectedMatches < 1)
+            {
+                throw new InvalidDataException(
+                    $"GML patch '{definition.Id}' must expect at least one anchor match.");
+            }
+
+            var target = ValidateTargetPath(definition.Target, definition.Id);
+            var anchorPath = ValidateRelativePath(definition.AnchorFile, "anchorFile", definition.Id);
+            var contentPath = ValidateRelativePath(definition.ContentFile, "contentFile", definition.Id);
+            var anchor = ReadRequiredSource(mod, anchorPath, "anchor", definition.Id);
+            var content = ReadRequiredSource(mod, contentPath, "content", definition.Id);
+            var beginMarker = $"// MOMI_GML_PATCH_BEGIN {definition.Id}";
+            var endMarker = $"// MOMI_GML_PATCH_END {definition.Id}";
+
+            patches.Add(new PreparedPatch(
+                definition,
+                target,
+                NormalizeNewLines(anchor),
+                NormalizeNewLines(content),
+                beginMarker,
+                endMarker));
+        }
+
+        return patches;
+    }
+
+    private Dictionary<string, TargetState> LoadTargets(IEnumerable<PreparedPatch> patches)
+    {
+        var targets = new Dictionary<string, TargetState>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var patch in patches)
+        {
+            if (targets.ContainsKey(patch.Target)) continue;
+
+            var destination = DestinationPath(patch.Target);
+            if (!fileModifier.Exists(destination))
+            {
+                throw new FileNotFoundException(
+                    $"GML patch target '{patch.Target}' does not exist in the game assets.",
+                    destination);
+            }
+
+            var original = fileModifier.Read(destination);
+            targets.Add(patch.Target, new TargetState(
+                destination,
+                DetectNewLine(original),
+                NormalizeNewLines(original)));
+        }
+
+        return targets;
+    }
+
+    private static string ApplyPatch(
+        string source,
+        PreparedPatch patch,
+        IReadOnlyList<int> matches)
+    {
+        var block = BuildMarkedBlock(patch);
+        var output = new StringBuilder(source.Length + block.Length * matches.Count);
+        var cursor = 0;
+
+        foreach (var match in matches)
+        {
+            output.Append(source, cursor, match - cursor);
+
+            switch (patch.Definition.Operation)
+            {
+                case "insert_before":
+                    AppendLineBlock(output, block, patch.Anchor[0]);
+                    output.Append(patch.Anchor);
+                    break;
+
+                case "insert_after":
+                    output.Append(patch.Anchor);
+                    AppendLineBlock(
+                        output,
+                        block,
+                        CharacterAtOrNull(source, match + patch.Anchor.Length));
+                    break;
+
+                case "replace_exact":
+                    AppendLineBlock(
+                        output,
+                        block,
+                        CharacterAtOrNull(source, match + patch.Anchor.Length));
+                    break;
+            }
+
+            cursor = match + patch.Anchor.Length;
+        }
+
+        output.Append(source, cursor, source.Length - cursor);
+        return output.ToString();
+    }
+
+    private static string BuildMarkedBlock(PreparedPatch patch)
+    {
+        var output = new StringBuilder(
+            patch.BeginMarker.Length + patch.Content.Length + patch.EndMarker.Length + 2);
+        output.Append(patch.BeginMarker).Append('\n').Append(patch.Content);
+        if (!patch.Content.EndsWith('\n')) output.Append('\n');
+        output.Append(patch.EndMarker);
+        return output.ToString();
+    }
+
+    private static void AppendLineBlock(StringBuilder output, string block, char? following)
+    {
+        if (output.Length > 0 && output[^1] != '\n') output.Append('\n');
+        output.Append(block);
+        if (following is not null and not '\n') output.Append('\n');
+    }
+
+    private static List<int> FindMatches(string source, string anchor)
+    {
+        var matches = new List<int>();
+        var offset = 0;
+
+        while (offset <= source.Length - anchor.Length)
+        {
+            var match = source.IndexOf(anchor, offset, StringComparison.Ordinal);
+            if (match < 0) break;
+
+            matches.Add(match);
+            offset = match + anchor.Length;
+        }
+
+        return matches;
+    }
+
+    private static bool ContainsMarker(string source, string marker) =>
+        source.Split('\n').Any(line => line.Trim() == marker);
+
+    private static void ValidatePatchId(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id) || !ValidPatchId.IsMatch(id))
+        {
+            throw new InvalidDataException(
+                "GML patch ids must be nonempty and contain only ASCII letters, digits, '.', '_', or '-'.");
+        }
+    }
+
+    private static string ValidateTargetPath(string path, string patchId)
+    {
+        var normalized = ValidateRelativePath(path, "target", patchId);
+        var segments = normalized.Split('/');
+
+        if (segments.Length < 2 ||
+            !segments[0].Equals("gml", StringComparison.OrdinalIgnoreCase) ||
+            !normalized.EndsWith(".gml", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidDataException(
+                $"GML patch '{patchId}' target must be a .gml file beneath the gml/ directory.");
+        }
+
+        return $"gml/{string.Join('/', segments.Skip(1))}";
+    }
+
+    private static string ValidateRelativePath(string path, string field, string patchId)
+    {
+        if (string.IsNullOrWhiteSpace(path) || path.IndexOf('\0') >= 0)
+        {
+            throw new InvalidDataException(
+                $"GML patch '{patchId}' has an empty or invalid {field} path.");
+        }
+
+        var normalized = path.Replace('\\', '/');
+        if (Path.IsPathRooted(path) || normalized.StartsWith('/') ||
+            Regex.IsMatch(normalized, "^[A-Za-z]:", RegexOptions.CultureInvariant))
+        {
+            throw new InvalidDataException(
+                $"GML patch '{patchId}' {field} path must be relative.");
+        }
+
+        var segments = normalized.Split('/');
+        if (segments.Any(segment => segment is "" or "." or ".."))
+        {
+            throw new InvalidDataException(
+                $"GML patch '{patchId}' {field} path contains an unsafe path segment.");
+        }
+
+        return string.Join('/', segments);
+    }
+
+    private static string ReadRequiredSource(IMod mod, string path, string kind, string patchId)
+    {
+        if (!mod.FileExists(path))
+        {
+            throw new FileNotFoundException(
+                $"GML patch '{patchId}' {kind} file does not exist: {path}",
+                path);
+        }
+
+        var source = mod.ReadFile(path);
+        if (string.IsNullOrWhiteSpace(source))
+        {
+            throw new InvalidDataException(
+                $"GML patch '{patchId}' {kind} file is empty: {path}");
+        }
+
+        return source;
+    }
+
+    private static string DetectNewLine(string source) =>
+        source.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+
+    private static string NormalizeNewLines(string source) =>
+        source.Replace("\r\n", "\n", StringComparison.Ordinal).Replace('\r', '\n');
+
+    private static string RestoreNewLines(string source, string newLine) =>
+        newLine == "\n" ? source : source.Replace("\n", newLine, StringComparison.Ordinal);
+
+    private static char? CharacterAtOrNull(string source, int index) =>
+        index < source.Length ? source[index] : null;
+
+    private sealed record PreparedPatch(
+        GmlPatchDefinition Definition,
+        string Target,
+        string Anchor,
+        string Content,
+        string BeginMarker,
+        string EndMarker);
+
+    private sealed class TargetState(string destination, string newLine, string content)
+    {
+        public string Destination { get; } = destination;
+        public string NewLine { get; } = newLine;
+        public string Content { get; set; } = content;
+    }
+}

--- a/ModsOfMistriaInstallerLib/ModInstaller.cs
+++ b/ModsOfMistriaInstallerLib/ModInstaller.cs
@@ -127,7 +127,11 @@ public class ModInstaller
         new MISTInstaller(fileNameUIDMapping, _fileModifier)
             .Install(effectiveMod, reportStatus);
 
-        // 6. Generate data-layer content from momi/ definitions (fiddle, outlines, asset_parts)
+        // 6. Apply manifest-declared, anchor-validated GML source patches
+        new GMLPatchInstaller(fileNameUIDMapping, _fileModifier)
+            .Install(mod, reportStatus);
+
+        // 7. Generate data-layer content from momi/ definitions (fiddle, outlines, asset_parts)
         new OutfitInstaller(fileNameUIDMapping, _fileModifier)
             .Install(mod, reportStatus);
         

--- a/ModsOfMistriaInstallerLib/ModTypes/FolderMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/FolderMod.cs
@@ -28,6 +28,8 @@ public class FolderMod : IMod
 
     private List<ModRequirement> _requirements = [];
 
+    private List<GmlPatchDefinition> _gmlPatches = [];
+
     private string? _updateUrl;
 
     private string? _downloadUrl;
@@ -64,6 +66,8 @@ public class FolderMod : IMod
     public string GetId() => Id;
 
     public List<ModRequirement> GetRequirements() => _requirements;
+
+    public List<GmlPatchDefinition> GetGmlPatches() => _gmlPatches;
 
     public string? GetUpdateUrl()   => _updateUrl;
     public string? GetDownloadUrl() => _downloadUrl;
@@ -103,6 +107,7 @@ public class FolderMod : IMod
             _minimumInstallerVersion = manifest.MinInstallerVersion,
             _manifestVersion = manifest.ManifestVersion,
             _requirements = manifest.Requirements,
+            _gmlPatches = manifest.GmlPatches,
             _updateUrl   = manifest.UpdateUrl,
             _downloadUrl = manifest.DownloadUrl
         };

--- a/ModsOfMistriaInstallerLib/ModTypes/GeneratedOverlayMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/GeneratedOverlayMod.cs
@@ -113,6 +113,7 @@ public class GeneratedOverlayMod : IMod
     public Validation Validate()             => _inner.Validate();
     public string GetBasePath()              => _inner.GetBasePath();
     public List<ModRequirement> GetRequirements() => _inner.GetRequirements();
+    public List<GmlPatchDefinition> GetGmlPatches() => _inner.GetGmlPatches();
     public string? GetUpdateUrl()   => _inner.GetUpdateUrl();
     public string? GetDownloadUrl() => _inner.GetDownloadUrl();
 

--- a/ModsOfMistriaInstallerLib/ModTypes/GmlPatchDefinition.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/GmlPatchDefinition.cs
@@ -1,0 +1,10 @@
+namespace Garethp.ModsOfMistriaInstallerLib.ModTypes;
+
+public record GmlPatchDefinition(
+    string Id,
+    string Target,
+    string Operation,
+    string AnchorFile,
+    string ContentFile,
+    int ExpectedMatches = 1
+);

--- a/ModsOfMistriaInstallerLib/ModTypes/IMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/IMod.cs
@@ -48,6 +48,8 @@ public interface IMod
 
     public List<ModRequirement> GetRequirements();
 
+    public List<GmlPatchDefinition> GetGmlPatches() => [];
+
     // URL used to check for updates (GitHub repo URL or custom JSON endpoint).
     // Null means no update checking for this mod.
     public string? GetUpdateUrl();

--- a/ModsOfMistriaInstallerLib/ModTypes/ModManifest.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/ModManifest.cs
@@ -11,6 +11,7 @@ public class ModManifest
     public readonly string MinInstallerVersion;
     public readonly string ManifestVersion;
     public List<ModRequirement> Requirements;
+    public List<GmlPatchDefinition> GmlPatches;
     public readonly string? DownloadUrl;
     public readonly string? UpdateUrl;
 
@@ -22,7 +23,8 @@ public class ModManifest
         string manifestVersion,
         List<ModRequirement> requirements, 
         string? downloadUrl, 
-        string? updateUrl
+        string? updateUrl,
+        List<GmlPatchDefinition>? gmlPatches = null
     ) {
         Name = name;
         Author = author;
@@ -30,6 +32,7 @@ public class ModManifest
         MinInstallerVersion = minInstallerVersion;
         ManifestVersion = manifestVersion;
         Requirements = requirements;
+        GmlPatches = gmlPatches ?? [];
         DownloadUrl = downloadUrl;
         UpdateUrl = updateUrl;
     }
@@ -50,7 +53,11 @@ public class ModManifest
             .Where(r => !string.IsNullOrEmpty(r.Name) && !string.IsNullOrEmpty(r.Author))
             .ToList(),
             json["download_url"]?.ToString(),
-            json["update_url"]?.ToString()
+            json["update_url"]?.ToString(),
+            (json["gmlPatches"] as JArray ?? [])
+                .OfType<JObject>()
+                .Select(ParseJsonGmlPatch)
+                .ToList()
         );
     }
 
@@ -62,6 +69,7 @@ public class ModManifest
         toml.TryGetValue("minInstallerVersion", out var minInstallerVersion);
         toml.TryGetValue("manifestVersion", out var manifestVersion);
         toml.TryGetValue("requirements", out var requirementsObject);
+        toml.TryGetValue("gmlPatches", out var gmlPatchesObject);
         toml.TryGetValue("download_url", out var downloadUrl);
         toml.TryGetValue("update_url", out var updateUrl);
 
@@ -93,7 +101,50 @@ public class ModManifest
             manifestVersion?.ToString() ?? "1",
             requirements,
             downloadUrl?.ToString(),
-            updateUrl?.ToString()
+            updateUrl?.ToString(),
+            GetTomlTables(gmlPatchesObject)
+                .Select(ParseTomlGmlPatch)
+                .ToList()
         );
     }
+
+    private static GmlPatchDefinition ParseJsonGmlPatch(JObject patch) => new(
+        patch["id"]?.ToString() ?? "",
+        patch["target"]?.ToString() ?? "",
+        patch["operation"]?.ToString() ?? "",
+        patch["anchorFile"]?.ToString() ?? "",
+        patch["contentFile"]?.ToString() ?? "",
+        ParseExpectedMatches(patch["expectedMatches"]?.ToString()));
+
+    private static GmlPatchDefinition ParseTomlGmlPatch(TomlTable patch)
+    {
+        patch.TryGetValue("id", out var id);
+        patch.TryGetValue("target", out var target);
+        patch.TryGetValue("operation", out var operation);
+        patch.TryGetValue("anchorFile", out var anchorFile);
+        patch.TryGetValue("contentFile", out var contentFile);
+        patch.TryGetValue("expectedMatches", out var expectedMatches);
+
+        return new GmlPatchDefinition(
+            id?.ToString() ?? "",
+            target?.ToString() ?? "",
+            operation?.ToString() ?? "",
+            anchorFile?.ToString() ?? "",
+            contentFile?.ToString() ?? "",
+            ParseExpectedMatches(expectedMatches?.ToString()));
+    }
+
+    private static IEnumerable<TomlTable> GetTomlTables(object? value)
+    {
+        if (value is IList<object?> unknownList)
+            return unknownList.OfType<TomlTable>();
+
+        if (value is IList<TomlTable> knownList)
+            return knownList;
+
+        return [];
+    }
+
+    private static int ParseExpectedMatches(string? value) =>
+        int.TryParse(value, out var expectedMatches) ? expectedMatches : 1;
 }

--- a/ModsOfMistriaInstallerLib/ModTypes/RarMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/RarMod.cs
@@ -31,6 +31,8 @@ public class RarMod() : IMod
 
     private List<ModRequirement> _requirements = [];
 
+    private List<GmlPatchDefinition> _gmlPatches = [];
+
     private string? _updateUrl;
 
     private string? _downloadUrl;
@@ -71,6 +73,7 @@ public class RarMod() : IMod
         _minimumInstallerVersion = manifest.MinInstallerVersion;
         _manifestVersion = manifest.ManifestVersion;
         _requirements = manifest.Requirements;
+        _gmlPatches = manifest.GmlPatches;
         _downloadUrl = manifest.DownloadUrl;
         _updateUrl = manifest.UpdateUrl;
         
@@ -239,6 +242,8 @@ public class RarMod() : IMod
     }
 
     public List<ModRequirement> GetRequirements() => _requirements;
+
+    public List<GmlPatchDefinition> GetGmlPatches() => _gmlPatches;
 
     public string? GetUpdateUrl()   => _updateUrl;
     public string? GetDownloadUrl() => _downloadUrl;

--- a/ModsOfMistriaInstallerLib/ModTypes/ZipMod.cs
+++ b/ModsOfMistriaInstallerLib/ModTypes/ZipMod.cs
@@ -31,6 +31,8 @@ public class ZipMod() : IMod
 
     private List<ModRequirement> _requirements = [];
 
+    private List<GmlPatchDefinition> _gmlPatches = [];
+
     private string? _updateUrl;
 
     private string? _downloadUrl;
@@ -56,6 +58,7 @@ public class ZipMod() : IMod
         _minimumInstallerVersion = manifest.MinInstallerVersion;
         _manifestVersion = manifest.ManifestVersion;
         _requirements = manifest.Requirements;
+        _gmlPatches = manifest.GmlPatches;
         _downloadUrl = manifest.DownloadUrl;
         _updateUrl = manifest.UpdateUrl;
         
@@ -223,6 +226,8 @@ public class ZipMod() : IMod
     }
 
     public List<ModRequirement> GetRequirements() => _requirements;
+
+    public List<GmlPatchDefinition> GetGmlPatches() => _gmlPatches;
 
     public string? GetUpdateUrl()   => _updateUrl;
     public string? GetDownloadUrl() => _downloadUrl;

--- a/ModsOfMistriaInstallerLib/Utils/ZipFileModifier.cs
+++ b/ModsOfMistriaInstallerLib/Utils/ZipFileModifier.cs
@@ -1,5 +1,5 @@
 ﻿using System.IO.Compression;
-using SixLabors.ImageSharp.Advanced;
+using System.Text;
 
 namespace Garethp.ModsOfMistriaInstallerLib.Utils;
 
@@ -49,11 +49,10 @@ public class ZipFileModifier(ZipArchive archive) : IFileModifier
 
     public void Write(string file, string contents)
     {
-        var stream = GetWriteStream(file);
-        stream.SetLength(contents.Length);
-        using var writer = new StreamWriter(stream);
+        using var stream = GetWriteStream(file);
+        stream.SetLength(0);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(false));
         writer.Write(contents);
-        writer.Close();
     }
 
     public Stream GetWriteStream(string file)

--- a/ModsOfMistriaInstallerLibTests/Installer/GMLPatchInstallerTest.cs
+++ b/ModsOfMistriaInstallerLibTests/Installer/GMLPatchInstallerTest.cs
@@ -1,0 +1,334 @@
+using Garethp.ModsOfMistriaInstallerLib.Installer;
+using Garethp.ModsOfMistriaInstallerLib.ModTypes;
+using Garethp.ModsOfMistriaInstallerLib.Utils;
+using ModsOfMistriaInstallerLibTests.Fixtures;
+using ModsOfMistriaInstallerLibTests.TestUtils;
+
+namespace ModsOfMistriaInstallerLibTests.Installer;
+
+public class GMLPatchInstallerTest
+{
+    private const string Target = "gml/scripts/example.gml";
+    private const string AnchorFile = "patches/anchor.gml";
+    private const string ContentFile = "patches/content.gml";
+
+    [TestCase("insert_before")]
+    [TestCase("insert_after")]
+    [TestCase("replace_exact")]
+    public void AppliesSupportedOperations(string operation)
+    {
+        var modifier = Modifier((Target, "alpha\nANCHOR\nomega"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch("example.test.operation", operation)]);
+        var statuses = new List<string>();
+
+        Installer(modifier).Install(mod, (message, _) => statuses.Add(message));
+
+        var result = modifier.GetFile(Destination(Target));
+        var begin = result.IndexOf("// MOMI_GML_PATCH_BEGIN example.test.operation", StringComparison.Ordinal);
+        var content = result.IndexOf("CONTENT", StringComparison.Ordinal);
+        var end = result.IndexOf("// MOMI_GML_PATCH_END example.test.operation", StringComparison.Ordinal);
+        var anchor = result.IndexOf("ANCHOR", StringComparison.Ordinal);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(begin, Is.GreaterThanOrEqualTo(0));
+            Assert.That(content, Is.GreaterThan(begin));
+            Assert.That(end, Is.GreaterThan(content));
+            Assert.That(statuses, Has.Count.EqualTo(1));
+        });
+
+        if (operation == "insert_before")
+            Assert.That(anchor, Is.GreaterThan(end));
+        else if (operation == "insert_after")
+            Assert.That(anchor, Is.LessThan(begin));
+        else
+            Assert.That(anchor, Is.EqualTo(-1));
+    }
+
+    [TestCase("\r\n", "\n")]
+    [TestCase("\n", "\r\n")]
+    public void MatchesAcrossNewLineStylesAndPreservesTargetStyle(
+        string targetNewLine,
+        string patchNewLine)
+    {
+        var original = string.Join(targetNewLine, ["alpha", "ANCHOR", "omega", ""]);
+        var content = string.Join(patchNewLine, ["first();", "second();"]);
+        var modifier = Modifier((Target, original));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, content)],
+            [Patch("example.test.newlines", "insert_after")]);
+
+        Installer(modifier).Install(mod, (_, _) => { });
+
+        var result = modifier.GetFile(Destination(Target));
+        if (targetNewLine == "\r\n")
+        {
+            var withoutCrLf = result.Replace("\r\n", "", StringComparison.Ordinal);
+            Assert.Multiple(() =>
+            {
+                Assert.That(withoutCrLf, Does.Not.Contain("\r"));
+                Assert.That(withoutCrLf, Does.Not.Contain("\n"));
+            });
+        }
+        else
+        {
+            Assert.That(result, Does.Not.Contain("\r"));
+        }
+    }
+
+    [TestCase("no matching text")]
+    [TestCase("ANCHOR\nANCHOR")]
+    public void RejectsUnexpectedMatchCountWithoutWriting(string original)
+    {
+        var modifier = Modifier((Target, original));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch("example.test.match-count", "insert_after")]);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+        Assert.That(modifier.TotalWrites, Is.Zero);
+    }
+
+    [Test]
+    public void AppliesTheDeclaredNumberOfMatches()
+    {
+        var modifier = Modifier((Target, "ANCHOR\nmiddle\nANCHOR"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch("example.test.two-matches", "insert_after", expectedMatches: 2)]);
+
+        Installer(modifier).Install(mod, (_, _) => { });
+
+        Assert.That(
+            CountOccurrences(
+                modifier.GetFile(Destination(Target)),
+                "// MOMI_GML_PATCH_BEGIN example.test.two-matches"),
+            Is.EqualTo(2));
+    }
+
+    [TestCase("data/scripts/example.gml")]
+    [TestCase("assets/gml/scripts/example.gml")]
+    [TestCase("gml/scripts/example.txt")]
+    [TestCase("gml/../data/example.gml")]
+    [TestCase("gml\\..\\data\\example.gml")]
+    [TestCase("C:\\game\\gml\\example.gml")]
+    [TestCase("/gml/scripts/example.gml")]
+    public void RejectsUnsafeOrOutOfScopeTargets(string target)
+    {
+        var modifier = Modifier((Target, "ANCHOR"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch("example.test.path", "insert_after", target)]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+        Assert.That(modifier.TotalWrites, Is.Zero);
+    }
+
+    [TestCase("")]
+    [TestCase("contains space")]
+    [TestCase("contains/slash")]
+    [TestCase("contains\nnewline")]
+    [TestCase("nonascii.é")]
+    public void RejectsUnsafePatchIds(string id)
+    {
+        var modifier = Modifier((Target, "ANCHOR"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch(id, "insert_after")]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+        Assert.That(modifier.TotalWrites, Is.Zero);
+    }
+
+    [TestCase(AnchorFile)]
+    [TestCase(ContentFile)]
+    public void RejectsMissingPatchSourceFiles(string pathToOmit)
+    {
+        var sourceFiles = new List<(string Path, string Content)>
+        {
+            (AnchorFile, "ANCHOR"),
+            (ContentFile, "CONTENT")
+        };
+        sourceFiles.RemoveAll(file => file.Path == pathToOmit);
+        var modifier = Modifier((Target, "ANCHOR"));
+        var mod = Mod(
+            sourceFiles,
+            [Patch("example.test.missing-source", "insert_after")]);
+
+        Assert.Throws<FileNotFoundException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+        Assert.That(modifier.TotalWrites, Is.Zero);
+    }
+
+    [Test]
+    public void RejectsDuplicatePatchIdsIgnoringCase()
+    {
+        var modifier = Modifier((Target, "ANCHOR"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [
+                Patch("example.test.duplicate", "insert_after"),
+                Patch("EXAMPLE.TEST.DUPLICATE", "insert_before")
+            ]);
+
+        Assert.Throws<InvalidDataException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+        Assert.That(modifier.TotalWrites, Is.Zero);
+    }
+
+    [Test]
+    public void RejectsApplyingTheSamePatchTwice()
+    {
+        var modifier = Modifier((Target, "ANCHOR"));
+        var mod = Mod(
+            [(AnchorFile, "ANCHOR"), (ContentFile, "CONTENT")],
+            [Patch("example.test.reapply", "insert_after")]);
+        var installer = Installer(modifier);
+
+        installer.Install(mod, (_, _) => { });
+
+        Assert.Throws<InvalidOperationException>(() =>
+            installer.Install(mod, (_, _) => { }));
+        Assert.That(modifier.WritesFor(Destination(Target)), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AppliesSequentialPatchesAndWritesTargetOnce()
+    {
+        const string secondAnchor = "patches/second-anchor.gml";
+        const string secondContent = "patches/second-content.gml";
+        var modifier = Modifier((Target, "ONE\nmiddle\nTWO"));
+        var mod = Mod(
+            [
+                (AnchorFile, "ONE"),
+                (ContentFile, "first();"),
+                (secondAnchor, "TWO"),
+                (secondContent, "second();")
+            ],
+            [
+                Patch("example.test.first", "insert_after"),
+                new GmlPatchDefinition(
+                    "example.test.second",
+                    Target,
+                    "insert_before",
+                    secondAnchor,
+                    secondContent)
+            ]);
+
+        Installer(modifier).Install(mod, (_, _) => { });
+
+        var result = modifier.GetFile(Destination(Target));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Does.Contain("first();"));
+            Assert.That(result, Does.Contain("second();"));
+            Assert.That(modifier.WritesFor(Destination(Target)), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void ValidationFailureDoesNotPartiallyWriteAnotherTarget()
+    {
+        const string otherTarget = "gml/scripts/other.gml";
+        const string otherAnchor = "patches/other-anchor.gml";
+        const string otherContent = "patches/other-content.gml";
+        var modifier = Modifier((Target, "FIRST"), (otherTarget, "SECOND"));
+        var mod = Mod(
+            [
+                (AnchorFile, "FIRST"),
+                (ContentFile, "first();"),
+                (otherAnchor, "NOT PRESENT"),
+                (otherContent, "second();")
+            ],
+            [
+                Patch("example.test.atomic-first", "insert_after"),
+                new GmlPatchDefinition(
+                    "example.test.atomic-second",
+                    otherTarget,
+                    "insert_after",
+                    otherAnchor,
+                    otherContent)
+            ]);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            Installer(modifier).Install(mod, (_, _) => { }));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(modifier.TotalWrites, Is.Zero);
+            Assert.That(modifier.GetFile(Destination(Target)), Is.EqualTo("FIRST"));
+            Assert.That(modifier.GetFile(Destination(otherTarget)), Is.EqualTo("SECOND"));
+        });
+    }
+
+    private static GMLPatchInstaller Installer(IFileModifier modifier) =>
+        new(new Dictionary<string, string>(), modifier);
+
+    private static GmlPatchDefinition Patch(
+        string id,
+        string operation,
+        string target = Target,
+        int expectedMatches = 1) =>
+        new(id, target, operation, AnchorFile, ContentFile, expectedMatches);
+
+    private static PatchMockMod Mod(
+        IEnumerable<(string Path, string Content)> files,
+        List<GmlPatchDefinition> patches) =>
+        new(files.ToDictionary(file => file.Path, file => file.Content), patches);
+
+    private static RecordingFileModifier Modifier(params (string Target, string Content)[] files) =>
+        new(files.ToDictionary(file => Destination(file.Target), file => file.Content));
+
+    private static string Destination(string target) =>
+        Path.Combine("assets", target.Replace('/', Path.DirectorySeparatorChar));
+
+    private static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = source.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += value.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class PatchMockMod(
+        Dictionary<string, string> files,
+        List<GmlPatchDefinition> patches)
+        : MockMod(files), IMod
+    {
+        public List<GmlPatchDefinition> GetGmlPatches() => patches;
+    }
+
+    private sealed class RecordingFileModifier(Dictionary<string, string> files) : IFileModifier
+    {
+        private readonly MockFileModifier _inner = new(files);
+        private readonly Dictionary<string, int> _writes = new(StringComparer.OrdinalIgnoreCase);
+
+        public int TotalWrites => _writes.Values.Sum();
+        public int WritesFor(string path) => _writes.GetValueOrDefault(path);
+        public string GetFile(string path) => _inner.GetFile(path);
+        public bool Exists(string file) => _inner.Exists(file);
+        public string Read(string file) => _inner.Read(file);
+        public Stream GetReadStream(string file) => _inner.GetReadStream(file);
+        public string[] FindFiles(string path, string pattern) => _inner.FindFiles(path, pattern);
+
+        public void Write(string file, string contents)
+        {
+            _writes[file] = WritesFor(file) + 1;
+            _inner.Write(file, contents);
+        }
+
+        public Stream GetWriteStream(string file) => _inner.GetWriteStream(file);
+        public bool ConditionalRestoreBackup(string file, Func<bool> condition) =>
+            _inner.ConditionalRestoreBackup(file, condition);
+    }
+}

--- a/ModsOfMistriaInstallerLibTests/ModTypes/ModManifestGmlPatchTest.cs
+++ b/ModsOfMistriaInstallerLibTests/ModTypes/ModManifestGmlPatchTest.cs
@@ -1,0 +1,102 @@
+using Garethp.ModsOfMistriaInstallerLib.ModTypes;
+using Newtonsoft.Json.Linq;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace ModsOfMistriaInstallerLibTests.ModTypes;
+
+[TestFixture]
+public class ModManifestGmlPatchTest
+{
+    [Test]
+    public void FromJsonParsesGmlPatchesAndDefaultsExpectedMatches()
+    {
+        var manifest = ModManifest.FromJson(JObject.Parse("""
+            {
+              "name": "Patch Mod",
+              "author": "Tester",
+              "version": "1.0.0",
+              "gmlPatches": [
+                {
+                  "id": "example.learn-food",
+                  "target": "gml/scripts/Items/UseItem.gml",
+                  "operation": "insert_after",
+                  "anchorFile": "patches/learn-food.anchor.gml",
+                  "contentFile": "patches/learn-food.content.gml",
+                  "expectedMatches": 2
+                },
+                {
+                  "id": "example.learn-drink",
+                  "target": "gml/scripts/Items/UseItem.gml",
+                  "operation": "insert_before",
+                  "anchorFile": "patches/learn-drink.anchor.gml",
+                  "contentFile": "patches/learn-drink.content.gml"
+                }
+              ]
+            }
+            """));
+
+        Assert.That(manifest.GmlPatches, Is.EqualTo(new List<GmlPatchDefinition>
+        {
+            new(
+                "example.learn-food",
+                "gml/scripts/Items/UseItem.gml",
+                "insert_after",
+                "patches/learn-food.anchor.gml",
+                "patches/learn-food.content.gml",
+                2),
+            new(
+                "example.learn-drink",
+                "gml/scripts/Items/UseItem.gml",
+                "insert_before",
+                "patches/learn-drink.anchor.gml",
+                "patches/learn-drink.content.gml",
+                1)
+        }));
+    }
+
+    [Test]
+    public void FromTomlParsesGmlPatchTableArray()
+    {
+        var toml = TomlSerializer.Deserialize<TomlTable>("""
+            name = "Patch Mod"
+            author = "Tester"
+            version = "1.0.0"
+
+            [[gmlPatches]]
+            id = "example.learn-food"
+            target = "gml/scripts/Items/UseItem.gml"
+            operation = "replace_exact"
+            anchorFile = "patches/learn-food.anchor.gml"
+            contentFile = "patches/learn-food.content.gml"
+            expectedMatches = 3
+            """)!;
+
+        var manifest = ModManifest.FromToml(toml);
+
+        Assert.That(manifest.GmlPatches, Is.EqualTo(new List<GmlPatchDefinition>
+        {
+            new(
+                "example.learn-food",
+                "gml/scripts/Items/UseItem.gml",
+                "replace_exact",
+                "patches/learn-food.anchor.gml",
+                "patches/learn-food.content.gml",
+                3)
+        }));
+    }
+
+    [Test]
+    public void MissingGmlPatchesProducesEmptyList()
+    {
+        var manifest = ModManifest.FromJson(JObject.Parse("""
+            {
+              "name": "No Patch Mod",
+              "author": "Tester",
+              "version": "1.0.0"
+            }
+            """));
+
+        Assert.That(manifest.GmlPatches, Is.Empty);
+    }
+}

--- a/ModsOfMistriaInstallerLibTests/Utils/ZipFileModifierTest.cs
+++ b/ModsOfMistriaInstallerLibTests/Utils/ZipFileModifierTest.cs
@@ -1,0 +1,34 @@
+using System.IO.Compression;
+using System.Text;
+using Garethp.ModsOfMistriaInstallerLib.Utils;
+
+namespace ModsOfMistriaInstallerLibTests.Utils;
+
+[TestFixture]
+public class ZipFileModifierTest
+{
+    [Test]
+    public void WriteTruncatesExistingEntryAndPreservesUtf8()
+    {
+        using var archiveStream = new MemoryStream();
+
+        using (var archive = new ZipArchive(archiveStream, ZipArchiveMode.Update, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("gml/test.gml");
+            using (var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false)))
+                writer.Write("This old text is much longer than the replacement.");
+
+            var modifier = new ZipFileModifier(archive);
+            modifier.Write("gml/test.gml", "café 🥕");
+        }
+
+        archiveStream.Position = 0;
+        using var resultArchive = new ZipArchive(archiveStream, ZipArchiveMode.Read);
+        using var reader = new StreamReader(
+            resultArchive.GetEntry("gml/test.gml")!.Open(),
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true);
+
+        Assert.That(reader.ReadToEnd(), Is.EqualTo("café 🥕"));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ new enough to install the mod and tell the user if they're unable to install the
 The `manifestVersion` field isn't used yet, but will allow for backwards compatibility in future versions of the installer
 if large changes are made to how mods are structured.
 
+### GML source patches
+
+Behavior mods can declare exact-text patches for existing GML files in `assets.zip`. Each patch references an anchor file
+and a content file shipped with the mod; MOMI does not scan or execute standalone installer scripts.
+
+```json
+{
+  "gmlPatches": [
+    {
+      "id": "author.mod.consume_hook",
+      "target": "gml/scripts/Player/AriFsm.gml",
+      "operation": "insert_after",
+      "anchorFile": "patches/consume.anchor.gml",
+      "contentFile": "patches/consume_hook.gml",
+      "expectedMatches": 1
+    }
+  ]
+}
+```
+
+Supported operations are `insert_before`, `insert_after`, and `replace_exact`. Patch IDs must be unique within the mod.
+Targets must be `.gml` files below `gml/`, while anchor and content paths must be safe relative paths inside the mod.
+MOMI normalizes line endings for matching, preserves the target's original line endings, and writes identifiable begin/end
+markers around inserted content. If an anchor does not match exactly `expectedMatches` times, or any declared patch is
+invalid, MOMI refuses the entire GML patch set before writing any target. Set `minInstallerVersion` to the first MOMI
+release that includes GML patch support.
+
 ### `fiddle/`
 JSON files in the `fiddle/` folder will get merged into the game's `__fiddle__.json` file. You can name the files however
 you want and have multiple JSON values in one file or split them up into multiple files as you see fit.


### PR DESCRIPTION
## Summary

- add manifest-declared exact-text GML source patches for folder, ZIP, and RAR mods
- support `insert_before`, `insert_after`, and `replace_exact` operations with explicit anchor match counts
- validate patch identifiers and paths, preserve target line endings, and add identifiable application markers
- prepare every GML target for a mod in memory before writing any target
- document the mod format and cover manifest parsing, patch safety, atomic validation, and UTF-8 archive rewrites

## Motivation

MOMI currently handles data and asset mods, but behavior mods that need to update an existing GML source must ship a separate installer or ask users to patch `assets.zip` manually. That creates platform-specific deployment logic and can trigger security tooling when packages contain PowerShell or command scripts.

This adds a declarative deployment mechanism that lets mods such as Taste to Learn describe the exact confirmed-consumption anchor and the GML content to insert. MOMI remains responsible for reading the mod package and updating the game archive.

## Safety and compatibility

- existing manifests without `gmlPatches` continue to produce an empty patch list
- targets are restricted to `.gml` files under `gml/`
- source paths must remain relative to the mod package
- patch IDs accept a restricted ASCII character set and must be unique per mod
- every anchor must match exactly `expectedMatches` times
- all patches for a mod are validated and applied in memory before target files are written
- each target is written once, even when multiple patches modify it
- ZIP writes now truncate entries correctly and preserve UTF-8 content

## Validation

- `dotnet test ModsOfMistriaInstaller.sln -c Release`
- 72 tests passed locally on .NET 8/Linux
- [GitHub Actions CI](https://github.com/supere989/Mods-of-Mistria-Installer/actions/runs/29207415250) passed on Ubuntu, Windows, and macOS
