### PR TITLE
 0.14.0-mmapi-gml-fixes-2

### DIFF
--- a/ModsOfMistriaInstallerLib/Seam/Payload/mmapi/mmapi_hotkeys.gml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/mmapi/mmapi_hotkeys.gml
@@ -69,6 +69,9 @@ function mmapi_hotkey_name_from_vk(vk) {
 
     // Named keys: find the name whose forward lookup yields this vk. This only runs on
     // a conflict (or a failed callback), so a linear scan of the vocabulary is fine.
+    // Each probe is guarded: the forward map reads bare vk_* constants, which the live
+    // runtime defines and the tier-1 VM does not, and a diagnostics path must never
+    // throw - a name that does not resolve just falls through to the "vk <ordinal>" form.
     var names = [
         "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
         "NUMPAD_0", "NUMPAD_1", "NUMPAD_2", "NUMPAD_3", "NUMPAD_4",
@@ -77,7 +80,9 @@ function mmapi_hotkey_name_from_vk(vk) {
         "CONTROL", "PAUSE_BREAK", "CAPS_LOCK", "NUM_LOCK", "SCROLL_LOCK",
     ];
     for (var i = 0; i < array_length(names); i++) {
-        if (mmapi_hotkey_vk_from_name(names[i]) == vk) { return names[i]; }
+        var candidate = undefined;
+        try { candidate = mmapi_hotkey_vk_from_name(names[i]); } catch (__mmapi_hotkey_vk_probe) {}
+        if (candidate == vk) { return names[i]; }
     }
     return "vk " + string(vk);
 }

--- a/ModsOfMistriaInstallerLib/Seam/Payload/mmapi/mmapi_hotkeys.gml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/mmapi/mmapi_hotkeys.gml
@@ -49,6 +49,39 @@ function mmapi_hotkey_vk_from_name(name) {
     return undefined;
 }
 
+// Reverse of mmapi_hotkey_vk_from_name: the friendly button name a vk resolves to,
+// for human-readable diagnostics (the conflict Warn / poll-failure Warn) instead of
+// a bare ordinal. A single digit/letter reverses straight to its character; the named
+// keys (F1-F12, NUMPAD_*, specials) probe the forward map so the two never drift.
+// Falls back to "vk <ordinal>" for a code with no supported name.
+function mmapi_hotkey_name_from_vk(vk) {
+    if (!is_real(vk)) { return "vk " + string(vk); }
+
+    // Digit or letter: the forward map used the ASCII code directly (ord). Reverse it
+    // by indexing the contiguous vocabulary (via string_char_at + ord rather than chr,
+    // which the live runtime has but the tier-1 VM's stdlib does not).
+    if (vk >= ord("0") && vk <= ord("9")) {
+        return string_char_at("0123456789", vk - ord("0") + 1);
+    }
+    if (vk >= ord("A") && vk <= ord("Z")) {
+        return string_char_at("ABCDEFGHIJKLMNOPQRSTUVWXYZ", vk - ord("A") + 1);
+    }
+
+    // Named keys: find the name whose forward lookup yields this vk. This only runs on
+    // a conflict (or a failed callback), so a linear scan of the vocabulary is fine.
+    var names = [
+        "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12",
+        "NUMPAD_0", "NUMPAD_1", "NUMPAD_2", "NUMPAD_3", "NUMPAD_4",
+        "NUMPAD_5", "NUMPAD_6", "NUMPAD_7", "NUMPAD_8", "NUMPAD_9",
+        "INSERT", "DELETE", "HOME", "PAGE_UP", "PAGE_DOWN", "SHIFT", "ALT",
+        "CONTROL", "PAUSE_BREAK", "CAPS_LOCK", "NUM_LOCK", "SCROLL_LOCK",
+    ];
+    for (var i = 0; i < array_length(names); i++) {
+        if (mmapi_hotkey_vk_from_name(names[i]) == vk) { return names[i]; }
+    }
+    return "vk " + string(vk);
+}
+
 function mmapi_hotkey_register(vk, callback, opts) {
     if (global[$ "__mmapi_hotkeys"] == undefined) { global.__mmapi_hotkeys = []; }
     var hotkeys = global.__mmapi_hotkeys;
@@ -59,7 +92,7 @@ function mmapi_hotkey_register(vk, callback, opts) {
     for (var i = 0; i < array_length(hotkeys); i++) {
         if (hotkeys[i].vk == vk) {
             mmapi_log_warn(mod_name,
-                "mmapi hotkey conflict: vk " + string(vk) + " is registered by "
+                "mmapi hotkey conflict: " + mmapi_hotkey_name_from_vk(vk) + " is registered by "
                 + hotkeys[i].mod_name + " and now also by " + mod_name
                 + ". Both will fire");
         }
@@ -81,7 +114,7 @@ function mmapi_hotkeys_poll() {
                 mmapi_warn_rate_limited(
                     "hotkey:" + string(entry.vk) + ":" + entry.mod_name,
                     entry.mod_name,
-                    "mmapi hotkey vk " + string(entry.vk) + " from "
+                    "mmapi hotkey " + mmapi_hotkey_name_from_vk(entry.vk) + " from "
                     + entry.mod_name + " failed: " + string(err));
             }
         }

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -23,7 +23,8 @@
 # Anchors are matched after normalizing \r\n to \n.
 # Apply order is catalog order plus `depends_on` edges (topo-sorted, stable).
 # Hook-less edits live in [[engine_fix]]: game_step_begin_installs (the mmapi
-# lifecycle root) and shroom_puddle_mask (a beta-wiring fix).
+# lifecycle root), shroom_puddle_mask (a beta-wiring fix), and
+# statue_hp_death_sweep (the griffin statue's missing depleted-hp death check).
 
 version = 2
 
@@ -1818,6 +1819,33 @@ replace = '''
                 .set_provenance(self.owner.monster_id, self.owner.stats_entry)
 '''
 marker  = "mmapi_hot_patch_damage_mask"
+
+# The Living Griffin Statue is the one hp-driven monster with no depleted-hp death
+# check outside its damage drain. Its only Dying transition sits inside
+# `if hit_points > 0 { ... if took_any_damage { ... } }`, so hp reaching zero without
+# a drained hit leaves it alive, hostile, and undamageable forever. The drain gate
+# never passes again. The fix adds the else branch every sibling of this drain
+# template carries (mite, bat, cat, enchantern).
+[[engine_fix]]
+name    = "statue_hp_death_sweep"
+file    = "gml/objects/obj_monster_statue.gml"
+anchor  = '''
+                    if self.hit_points <= 0 {
+                        self.fsm.change_state(StatueState.Dying);
+                    }
+                }
+            }
+        },'''
+replace = '''
+                    if self.hit_points <= 0 {
+                        self.fsm.change_state(StatueState.Dying);
+                    }
+                }
+            } else if csi != StatueState.Dying {
+                self.fsm.change_state(StatueState.Dying); // mmapi_statue_hp_sweep
+            }
+        },'''
+marker  = "mmapi_statue_hp_sweep"
 
 # The remaining entries are appended after the earlier ones on purpose. Catalog
 # order is apply order, and two of them stack onto files already seamed above

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -204,7 +204,7 @@ doc  = "Fires from the begin_step derived-events poll when total_days() changes.
 name = "game.room_changed"
 kind = "event"
 provider = "runtime"
-doc  = "Fires from the begin_step derived-events poll when room() changes, after room_start has already run. ctx is { previous, current } (gm_room values). Observation only: to change room content as it loads, use the in-file seams (dungeon.floor_enter and the room transition events) instead."
+doc  = "Fires from the begin_step derived-events poll when room() changes, after room_start has already run. ctx is { previous, current } (gm_room values). Observation only: to change room content as it loads, use the in-file seams (dungeon.floor_enter and the room transition events) instead. Do not cache ctx.current for a later decision: the poll lags the real transition by a frame or more, no event fires for the room a session starts in (a save loaded in-place leaves any cache empty until the next change), and the ctx values are gm_room ASSETS, not name strings. Read room() live at the point of use (asset_to_string(room()) for the name) and treat this event as an edge trigger only; for request-time semantics, use game.room_transition_pre."
 
 [[hook]]
 name = "game.room_transition_post"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -175,6 +175,11 @@ kind = "filter"
 doc  = "Filters the spawn chance passed to try_create_side_room() at the head of that function, before the per-floor roll. ctx is { impl, is_ritual, max_flr }; is_ritual is true when impl == DungeonImpl.Ritual (the pre-computed convenience flag so consumers need not reference the DungeonImpl enum). Return an adjusted chance (0-100) to raise/lower the odds of a treasure/ritual side room; return the value unchanged (or undefined) to defer. Fires for every side-room impl the runner attempts."
 
 [[hook]]
+name = "fishing.should_reel"
+kind = "filter"
+doc  = "Fires every step of the player fishing FSM's Wait state, after bite notification handling and before the retract sound, caught/missed handling, and Reel transitions. The filtered value is whether the player requested a reel through the normal tool inputs. ctx is { bite_active }, true while FISHING.bite_timer is positive. Return a replacement boolean, or undefined to keep the current value. The final true value runs the complete vanilla reel block; false remains in Wait. Hot while waiting for a fish."
+
+[[hook]]
 name = "fsm.transition"
 kind = "filter"
 doc  = "Fires in __StateMachine.execute_state_change(), once per executed state transition of every shared-FSM machine in the game (monsters, the player and the fishing sub-machine, NPCs, animals, birds, fish and fish schools, the camera, cameos, the bobber), before the outgoing state's stop() runs. The filtered value is the struct { fsm, owner, from, to, cancel: false }: fsm is the machine, owner is whatever spawn() received (an instance for monsters, NPCs, and the player; a struct for the camera and the fishing sub-machine, so check is_struct before touching instance fields), from and to are the machine's per-species enum state ids (CatState.*, TomeState.*, MushroomState.*, PlayerState.*, and so on, resolvable by name in mod GML). Return the replacement struct, or mutate it in place and return undefined; the seam re-reads fields defensively. Set cancel to true to skip the transition entirely (no stop or start runs, the machine keeps its state, and state_frame stalls for that tick); set to to a different valid state id of the same machine to redirect (non-numeric, fractional, or out-of-range values are ignored). Redirect via the struct, never by calling change_state from inside a handler. The initial state entered at spawn does not dispatch. Deferred requests overwritten before new_tick never dispatch. A cancelled transition that the owner re-requests every step re-dispatches every tick for that instance while the cancel holds. Transitions are edge events, not per-frame."
@@ -1259,6 +1264,23 @@ replace = '''
                         }'''
 marker  = "mmapi_spell_default_cost"
 provides = ["spells.cost"]
+
+# FishingState.Windup contains the same input expression. The following
+# fishing_sfx line makes this the one Wait-state gate, where a true result runs
+# the complete pristine retract/caught-or-missed/Reel block.
+[[seam]]
+id      = "fishing_should_reel"
+file    = "gml/scripts/Player/AriFsm.gml"
+anchor  = '''
+                        if INPUT.check(InputId.UseToolCharged) || INPUT.check(InputId.UseToolRepeated) {
+                            var fishing_sfx = fiddle_get("tool_fx/fishing");'''
+replace = '''
+                        var __mmapi_fishing_should_reel = INPUT.check(InputId.UseToolCharged) || INPUT.check(InputId.UseToolRepeated);
+                        try { __mmapi_fishing_should_reel = mmapi_apply_filters("fishing.should_reel", __mmapi_fishing_should_reel, { bite_active: FISHING.bite_timer > 0 }); } catch (__mmapi_fishing_should_reel_error) {} // mmapi_fishing_run_should_reel_filters
+                        if (__mmapi_fishing_should_reel) {
+                            var fishing_sfx = fiddle_get("tool_fx/fishing");'''
+marker  = "mmapi_fishing_run_should_reel_filters"
+provides = ["fishing.should_reel"]
 
 [[seam]]
 id      = "player_equipment_bonus"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -338,6 +338,16 @@ kind = "filter"
 doc  = "Fires at the return of the player's equipment bonus lookup. The filtered value is the computed bonus. ctx is { player, infusion, key }. Return the replacement value, or undefined to keep the current value."
 
 [[hook]]
+name = "player.essence_delta"
+kind = "filter"
+doc  = "Fires at the top of Ari.modify_essence(), before the delta is applied. The filtered value is the signed essence delta: morsel pickups, item gains, and ritual refunds are positive; shrine offerings and essence craft costs are negative. ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. The seam floors the filtered result at -essence so the total never goes negative: set_essence has no floor of its own, and a negative total arms the engine's essence assert, which crashes on the NEXT essence change. The floor never binds on engine values (every vanilla spend is affordability-gated first). Absolute sets (save load, new game, debug) do not route through modify_essence and never fire this hook. Morsel-based gains land here per collected morsel, after gain_essence()'s overflow accrual and Requirement.CollectEssence gate."
+
+[[hook]]
+name = "player.gold_delta"
+kind = "filter"
+doc  = "Fires at the top of Ari.modify_gold(), before the delta is applied. The filtered value is the signed gold delta: sales, rewards, and grants positive; purchases, fees, and craft costs negative. A store checkout arrives as one negative delta of the whole basket total (a sale arrives the same way with the sign flipped). ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. set_gold floors the result at 0 and truncates fractions, so an overdrawing replacement safely bottoms out at broke. Absolute sets (save load, new game, debug) do not route through modify_gold and never fire this hook."
+
+[[hook]]
 name = "player.heal_vfx"
 kind = "guard"
 doc  = "Fires at the top of play_heal_vfx(). ctx is { color, sprite }. Return false to veto the heal vfx. Undefined or true allows."
@@ -351,6 +361,11 @@ doc  = "Fires at the top of Ari.modify_health(), before the delta is applied. Th
 name = "player.incoming_damage"
 kind = "filter"
 doc  = "Fires in the player's damage drain in obj_ari, after mitigation is applied. The filtered value is the final signed damage (health only changes while it is negative). ctx is { player, receiver, tarball }. Return the replacement damage or undefined to keep the current value. A combat.damage filter can set the ctx.tarball fields __mmapi_player_show_damage_popup and __mmapi_player_should_flinch to false to suppress the damage popup and flinch, and with both false and non-negative damage the hit is skipped entirely. mmapi_deal_damage()'s show_popup and flinch opts ride the same two fields."
+
+[[hook]]
+name = "player.mana_delta"
+kind = "filter"
+doc  = "Fires at the top of Ari.modify_mana(), before the delta is applied. The filtered value is the signed mana delta: cast deductions negative, restores positive. ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. set_mana clamps the result to [0, mana_max], so any replacement is safe. A companion seam reroutes the mana potion's direct set_mana call through modify_mana, so item restores fire this hook too; cutscene absolute sets and save load do not. Composes with spells.cost: a cast's deduction arrives here as the negative of the already-filtered cost, so prefer spells.cost for spell pricing and this hook for everything else."
 
 [[hook]]
 name = "player.max_health_item"
@@ -381,6 +396,11 @@ doc  = "Fires in StatusEffectManager.update() when an effect's finish time lapse
 name = "player.status_effect_register"
 kind = "filter"
 doc  = "Fires at the top of StatusEffectManager.register(). The filtered value is the struct { type, amount, start_time, finish_time, can_stack, show_hud }. ctx is the manager. Return the replacement struct. The seam tolerates an undefined return and re-reads each field defensively."
+
+[[hook]]
+name = "player.xp_delta"
+kind = "filter"
+doc  = "Fires at the top of Ari.gain_xp(skill, xp, silent), before the XP is applied. The filtered value is the XP delta; ctx is { player, skill, silent }, skill being the Skill.* enum id. Return the replacement delta, or undefined to keep the current value. A negative delta genuinely deducts XP and can lower the skill's level: the seam floors the filtered result at -skill_xp[skill] so the total never goes negative (levels 0 and 1 cost 0 XP, so the computed level bottoms out at 1, never the -1 a negative total would read as), and the seam narrows the level celebration to genuine gains, so a level DOWN does not play the LevelUp chime and dingaling (vanilla celebrates any level change; the narrowed condition is unreachable without a negative delta). The floor never binds on engine values (vanilla deltas are all non-negative). The engine's own cap at MAX_SKILL_LEVEL_COSTS still applies after the filter, and already-granted level rewards are not revoked by leveling down."
 
 [[hook]]
 name = "resource.node_modifier"
@@ -1370,6 +1390,119 @@ var     = "amount_to_add"
 indent  = 8
 try_catch = false
 marker  = "mmapi_player_run_stamina_delta_filters"
+
+# The essence delta filter carries its own floor: set_essence has no lower
+# clamp, and a negative total arms the engine's assert(essence >= 0), which
+# crashes on the NEXT essence change - far from the handler that caused it.
+# The floor (and the is_real/is_int64 type guard in front of it) only binds
+# on handler output vanilla never produces, so with zero handlers the edit
+# is behaviorally equivalent to pristine.
+[[seam]]
+id      = "player_essence_delta"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+anchor  = '''
+    function modify_essence(amount_to_add) {
+        self.set_essence(self.essence + amount_to_add);
+    }'''
+replace = '''
+    function modify_essence(amount_to_add) {
+        try {
+            var __mmapi_essence_delta = mmapi_apply_filters("player.essence_delta", amount_to_add, { player: self }); // mmapi_player_run_essence_delta_filters
+            if (is_real(__mmapi_essence_delta) || is_int64(__mmapi_essence_delta)) {
+                amount_to_add = max(__mmapi_essence_delta, -self.essence);
+            }
+        } catch (__mmapi_essence_delta_err) {}
+        self.set_essence(self.essence + amount_to_add);
+    }'''
+marker  = "mmapi_player_run_essence_delta_filters"
+provides = ["player.essence_delta"]
+
+[[seam]]
+id      = "player_gold_delta"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+context_before = '''
+    function modify_gold(amount_to_add) {
+'''
+context_after = '''
+        self.set_gold(self.gold + amount_to_add);
+    }'''
+op      = "filter"
+hook    = "player.gold_delta"
+ctx     = "{ player: self }"
+var     = "amount_to_add"
+indent  = 8
+try_catch = false
+marker  = "mmapi_player_run_gold_delta_filters"
+
+[[seam]]
+id      = "player_mana_delta"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+context_before = '''
+    function modify_mana(amount_to_add) {
+'''
+context_after = '''
+        var o = get_mana();
+        set_mana(o + amount_to_add);
+    }'''
+op      = "filter"
+hook    = "player.mana_delta"
+ctx     = "{ player: self }"
+var     = "amount_to_add"
+indent  = 8
+try_catch = false
+marker  = "mmapi_player_run_mana_delta_filters"
+
+# The one gameplay-delta mana change that bypasses modify_mana: the mana
+# potion consumes via set_mana(mana_current + modifier). modify_mana(x) is
+# literally set_mana(get_mana() + x), so the reroute is behavior-identical
+# and brings item restores into the player.mana_delta filter.
+[[seam]]
+id      = "player_mana_item_delta"
+file    = "gml/scripts/Player/AriFsm.gml"
+anchor  = '''
+                            ARI.set_mana(ARI.mana_current + self.live_item.prototype.mana_modifier);'''
+replace = '''
+                            ARI.modify_mana(self.live_item.prototype.mana_modifier); // mmapi_player_mana_item_delta'''
+marker  = "mmapi_player_mana_item_delta"
+provides = ["player.mana_delta"]
+
+# The XP delta filter floors the running total at zero: skill_xp has no
+# lower clamp, and skill_xp_to_level() reads a negative total as level -1.
+# Levels 0 and 1 cost 0 XP, so the floored level bottoms out at 1. The same
+# edit narrows the level celebration from `!=` to `<`, so a level DOWN does
+# not play the LevelUp chime and dingaling - a branch vanilla cannot reach,
+# since every vanilla delta is non-negative.
+[[seam]]
+id      = "player_xp_delta"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+anchor  = '''
+    function gain_xp(skill, xp, silent=false) {
+        var old_skill_level = ARI.level(skill);
+
+        self.skill_xp[skill] = min(
+            self.skill_xp[skill] + xp,
+            MAX_SKILL_LEVEL_COSTS[skill],
+        );
+
+        if !silent && old_skill_level != ARI.level(skill) {'''
+replace = '''
+    function gain_xp(skill, xp, silent=false) {
+        try {
+            var __mmapi_xp_delta = mmapi_apply_filters("player.xp_delta", xp, { player: self, skill: skill, silent: silent }); // mmapi_player_run_xp_delta_filters
+            if (is_real(__mmapi_xp_delta) || is_int64(__mmapi_xp_delta)) {
+                xp = max(__mmapi_xp_delta, -self.skill_xp[skill]);
+            }
+        } catch (__mmapi_xp_delta_err) {}
+        var old_skill_level = ARI.level(skill);
+
+        self.skill_xp[skill] = min(
+            self.skill_xp[skill] + xp,
+            MAX_SKILL_LEVEL_COSTS[skill],
+        );
+
+        if !silent && old_skill_level < ARI.level(skill) {'''
+marker  = "mmapi_player_run_xp_delta_filters"
+provides = ["player.xp_delta"]
 
 [[seam]]
 id      = "player_move_speed"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -378,6 +378,11 @@ kind = "filter"
 doc  = "Fires at the end of the player's move speed computation, after the status effect multipliers. The filtered value is the speed. ctx is { player, on_mount }. Return the replacement speed, or undefined to keep the current value."
 
 [[hook]]
+name = "player.renown_delta"
+kind = "filter"
+doc  = "Fires at the top of Ari.modify_renown(), before the delta is applied. The filtered value is the renown delta. The engine's one gameplay caller is the on_new_day drain of pending_renown_entries, so this fires at day rollover, once per pending entry (quest completions, museum donations, the prior day's shipping gold). ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. set_renown clamps the resulting total to [0, max renown], so any replacement is safe: a negative delta lowers renown and the computed level, plays no celebration, and never revokes already-granted level rewards, while a gain that crosses several levels grants each crossed level's reward. The end-of-day menu tallies the raw pending entries before the drain, so its renown-earned figure shows unfiltered values. Absolute sets (debug, test suite, new game) do not route through modify_renown and never fire this hook."
+
+[[hook]]
 name = "player.stamina_delta"
 kind = "filter"
 doc  = "Fires at the top of Ari.modify_stamina(), before stamina_costs_modifier is applied. The filtered value is the signed stamina delta. ctx is { player }. Return the replacement delta, or undefined to keep the current value."
@@ -1503,6 +1508,23 @@ replace = '''
         if !silent && old_skill_level < ARI.level(skill) {'''
 marker  = "mmapi_player_run_xp_delta_filters"
 provides = ["player.xp_delta"]
+
+[[seam]]
+id      = "player_renown_delta"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+context_before = '''
+    function modify_renown(amount_to_add) {
+'''
+context_after = '''
+        self.set_renown(self.renown + amount_to_add);
+    }'''
+op      = "filter"
+hook    = "player.renown_delta"
+ctx     = "{ player: self }"
+var     = "amount_to_add"
+indent  = 8
+try_catch = false
+marker  = "mmapi_player_run_renown_delta_filters"
 
 [[seam]]
 id      = "player_move_speed"

--- a/ModsOfMistriaInstallerLibTests/Fixtures/GmlRuntime/dispatch_runtime/dispatch_isolation.gml
+++ b/ModsOfMistriaInstallerLibTests/Fixtures/GmlRuntime/dispatch_runtime/dispatch_isolation.gml
@@ -37,7 +37,7 @@ deq("a throwing override is skipped and the next one still answers",
 
 // ── The unguarded seam shapes, reproduced verbatim ──────────────────────────
 //
-// Most seams wrap their dispatcher call in a try/catch, 73 of 93. These two do
+// Most seams wrap their dispatcher call in a try/catch, 74 of 94. These two do
 // not, and the claim to test is that a callback throwing under them crashes the
 // game. It does not: the dispatcher guards each handler itself, so the seam's
 // try/catch was never what protected the callback.

--- a/ModsOfMistriaInstallerLibTests/Fixtures/GmlRuntime/dispatch_runtime/dispatch_isolation.gml
+++ b/ModsOfMistriaInstallerLibTests/Fixtures/GmlRuntime/dispatch_runtime/dispatch_isolation.gml
@@ -37,10 +37,17 @@ deq("a throwing override is skipped and the next one still answers",
 
 // ── The unguarded seam shapes, reproduced verbatim ──────────────────────────
 //
-// Most seams wrap their dispatcher call in a try/catch, 74 of 94. These two do
-// not, and the claim to test is that a callback throwing under them crashes the
-// game. It does not: the dispatcher guards each handler itself, so the seam's
-// try/catch was never what protected the callback.
+// Two layers of protection exist at a seam, guarding different code. The
+// dispatcher wraps every HANDLER call itself, so a throwing mod callback is
+// always contained, at every seam. The seam's own try/catch (the try_catch
+// template option) guards the SEAM's code instead: a ctx expression that
+// reads live engine state, or a write-back after the dispatch. A few seams
+// skip that site catch because their dispatch line is provably total - a
+// literal ctx like { player: self } and a bare assignment of the return have
+// nothing left to fail. The worry this section retires is that those bare
+// seams are unprotected against throwing callbacks: they are not, because
+// callback isolation never came from the site catch. Both bare shapes below
+// reproduce real catalog seams and survive a thrower.
 
 // player_move_speed's seam body, in shape: no try/catch anywhere.
 function i_move_speed_seam() {

--- a/docs/MMAPI/API_REFERENCE.md
+++ b/docs/MMAPI/API_REFERENCE.md
@@ -209,7 +209,15 @@ if (_id != undefined) { ARI.give_item(_id, 1); }
 ARI.modify_gold(500);
 
 // Show the toast notification popup. Once per real event, not every frame.
-create_notification("Something happened");
+// The argument is a LOCALIZATION KEY, resolved engine-side through local_get
+// - inside the local_get_dispatch rewrite, so local.get filters apply (pass
+// the key, never pre-localized text). Register your own keys via fiddle
+// strings + l10n fiddle_renames: see Mod Anatomy's "User-Facing Text".
+// Optional second arg suppresses repeats of the same key, in frames.
+create_notification("misc_local/known_recipe");
+create_notification("mods/my_mod/notifications/something_happened", 60 * 5);
+// Prototypes only (untranslatable, bypasses filters):
+create_notification(ANCHOR.wrap_for_local("Something happened"));
 
 // Teleport the player to a named location, at pixel coordinates in that room.
 if (instance_exists(obj_ari)) {

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **87 hooks**, fed by **93 seams**, **2 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **87 hooks**, fed by **93 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -247,6 +247,7 @@ Hook-less edits the catalog also carries:
 | ---- | ---- | ----------- |
 | [game_step_begin_installs](seams/game_step_begin_installs.md) | engine fix | Installs the MMAPI per-frame drain at the top of the game's `step_begin`, the framework's lifecycle root. |
 | [shroom_puddle_mask](seams/shroom_puddle_mask.md) | engine fix | Corrects the acid puddle's damage-tarball collision mask, a beta-wiring fix. |
+| [statue_hp_death_sweep](seams/statue_hp_death_sweep.md) | engine fix | Adds the Living Griffin Statue's missing depleted-hp death check, closing a potential soft-lock and matching every other monster's sweep. |
 | [local_get_dispatch](seams/local_get_dispatch.md) | call rewrite | Reroutes every direct GML `local_get()` call through the framework's localisation waist, feeding [local.get](hooks/local.get.md) and [local.missing](hooks/local.missing.md). |
 
 ## Growing The Catalog

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **87 hooks**, fed by **93 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **88 hooks**, fed by **94 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -60,6 +60,7 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [player.status_effect_register](hooks/player.status_effect_register.md) | filter | Rewrite a status effect as it registers. |
 | [player.status_effect_cancel](hooks/player.status_effect_cancel.md) | event | Know when the game cancels a status effect. |
 | [player.status_effect_expired](hooks/player.status_effect_expired.md) | event | Know the moment a status effect runs out. |
+| [fishing.should_reel](hooks/fishing.should_reel.md) | filter | Change whether the player reels from the fishing Wait state this frame. |
 | [npc.heart_points](hooks/npc.heart_points.md) | filter | Adjust the heart points a villager gains. |
 | [npc.gift_received](hooks/npc.gift_received.md) | event | Know when the player gives an NPC a gift. |
 | [animal.heart_points](hooks/animal.heart_points.md) | filter | Adjust the heart points a barn animal gains. |
@@ -167,6 +168,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_status_effect_register](seams/player_status_effect_register.md) | Filters every status effect's fields at the top of `register()`. |
 | [player_status_effect_cancel](seams/player_status_effect_cancel.md) | Emits at the head of `StatusEffectManager.cancel()`, before any lookup. |
 | [player_status_effect_expired](seams/player_status_effect_expired.md) | Emits inside `update()`'s expiry branch, right after the effect is removed. |
+| [fishing_should_reel](seams/fishing_should_reel.md) | Filters the Wait state's reel decision before the complete vanilla reel block. |
 | [npc_heart_points](seams/npc_heart_points.md) | Reroutes every villager heart-point delta through a filter before it lands. |
 | [npc_receive_gift](seams/npc_receive_gift.md) | Announces every gift the moment an NPC receives it. |
 | [animal_heart_points](seams/animal_heart_points.md) | Reroutes every barn-animal heart-point delta through a filter before it lands. |

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **88 hooks**, fed by **94 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **92 hooks**, fed by **99 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -50,10 +50,14 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 
 | Name | Kind | Description |
 | ---- | ---- | ----------- |
-| [player.health_delta](hooks/player.health_delta.md) | filter | Change every player health gain or loss before it lands. |
+| [player.health_delta](hooks/player.health_delta.md) | filter | Change every player health gain or loss before it applies. |
 | [player.stamina_delta](hooks/player.stamina_delta.md) | filter | Change every stamina cost or gain before it applies. |
 | [player.incoming_damage](hooks/player.incoming_damage.md) | filter | Change the final damage a hit deals the player. |
 | [player.move_speed](hooks/player.move_speed.md) | filter | Change the player's move speed after every engine modifier. |
+| [player.essence_delta](hooks/player.essence_delta.md) | filter | Change every essence gain or spend before it applies. |
+| [player.gold_delta](hooks/player.gold_delta.md) | filter | Change every gold gain or spend before it applies. |
+| [player.mana_delta](hooks/player.mana_delta.md) | filter | Change every mana gain or spend before it applies. |
+| [player.xp_delta](hooks/player.xp_delta.md) | filter | Change every skill XP gain before it applies, or turn it into a deduction. |
 | [player.equipment_bonus](hooks/player.equipment_bonus.md) | filter | Adjust the bonus an equipment infusion grants the player. |
 | [player.max_health_item](hooks/player.max_health_item.md) | event | Know when an item permanently raises Ari's max health. |
 | [player.heal_vfx](hooks/player.heal_vfx.md) | guard | Block the player's heal sparkle before it plays. |
@@ -160,6 +164,11 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | ---- | ----------- |
 | [player_health_delta](seams/player_health_delta.md) | Filters the signed health delta at the top of `Ari.modify_health()`. |
 | [player_stamina_delta](seams/player_stamina_delta.md) | Filters the signed stamina delta before the stamina cost modifier applies. |
+| [player_essence_delta](seams/player_essence_delta.md) | Filters the signed essence delta at the top of `Ari.modify_essence()`, floored so the total never goes negative. |
+| [player_gold_delta](seams/player_gold_delta.md) | Filters the signed gold delta at the top of `Ari.modify_gold()`. |
+| [player_mana_delta](seams/player_mana_delta.md) | Filters the signed mana delta at the top of `Ari.modify_mana()`. |
+| [player_mana_item_delta](seams/player_mana_item_delta.md) | Reroutes the mana potion's direct `set_mana` call through `modify_mana`, so item restores fire the mana filter. |
+| [player_xp_delta](seams/player_xp_delta.md) | Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and narrows the level celebration to genuine gains. |
 | [player_incoming_damage](seams/player_incoming_damage.md) | Rewrites the player's damage drain so mods filter the final damage and its popup and flinch side effects. |
 | [player_move_speed](seams/player_move_speed.md) | Filters the player's computed move speed after the status-effect multipliers. |
 | [player_equipment_bonus](seams/player_equipment_bonus.md) | Rewrites the equipment bonus lookup's return into a filtered return. |
@@ -169,9 +178,9 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_status_effect_cancel](seams/player_status_effect_cancel.md) | Emits at the head of `StatusEffectManager.cancel()`, before any lookup. |
 | [player_status_effect_expired](seams/player_status_effect_expired.md) | Emits inside `update()`'s expiry branch, right after the effect is removed. |
 | [fishing_should_reel](seams/fishing_should_reel.md) | Filters the Wait state's reel decision before the complete vanilla reel block. |
-| [npc_heart_points](seams/npc_heart_points.md) | Reroutes every villager heart-point delta through a filter before it lands. |
+| [npc_heart_points](seams/npc_heart_points.md) | Reroutes every villager heart-point delta through a filter before it applies. |
 | [npc_receive_gift](seams/npc_receive_gift.md) | Announces every gift the moment an NPC receives it. |
-| [animal_heart_points](seams/animal_heart_points.md) | Reroutes every barn-animal heart-point delta through a filter before it lands. |
+| [animal_heart_points](seams/animal_heart_points.md) | Reroutes every barn-animal heart-point delta through a filter before it applies. |
 | [animal_on_pet](seams/animal_on_pet.md) | Announces the moment the player pets a barn animal. |
 | [animal_put_down](seams/animal_put_down.md) | Announces the moment a held animal is set back down. |
 | [combat_damage_pre](seams/combat_damage_pre.md) | Threads every enqueued hit through a damage filter before it resolves. |

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **92 hooks**, fed by **99 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **93 hooks**, fed by **100 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -58,6 +58,7 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [player.gold_delta](hooks/player.gold_delta.md) | filter | Change every gold gain or spend before it applies. |
 | [player.mana_delta](hooks/player.mana_delta.md) | filter | Change every mana gain or spend before it applies. |
 | [player.xp_delta](hooks/player.xp_delta.md) | filter | Change every skill XP gain before it applies, or turn it into a deduction. |
+| [player.renown_delta](hooks/player.renown_delta.md) | filter | Change every renown gain before it applies, or turn it into a deduction. |
 | [player.equipment_bonus](hooks/player.equipment_bonus.md) | filter | Adjust the bonus an equipment infusion grants the player. |
 | [player.max_health_item](hooks/player.max_health_item.md) | event | Know when an item permanently raises Ari's max health. |
 | [player.heal_vfx](hooks/player.heal_vfx.md) | guard | Block the player's heal sparkle before it plays. |
@@ -169,6 +170,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_mana_delta](seams/player_mana_delta.md) | Filters the signed mana delta at the top of `Ari.modify_mana()`. |
 | [player_mana_item_delta](seams/player_mana_item_delta.md) | Reroutes the mana potion's direct `set_mana` call through `modify_mana`, so item restores fire the mana filter. |
 | [player_xp_delta](seams/player_xp_delta.md) | Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and narrows the level celebration to genuine gains. |
+| [player_renown_delta](seams/player_renown_delta.md) | Filters the renown delta at the top of `Ari.modify_renown()`, once per pending entry at day rollover. |
 | [player_incoming_damage](seams/player_incoming_damage.md) | Rewrites the player's damage drain so mods filter the final damage and its popup and flinch side effects. |
 | [player_move_speed](seams/player_move_speed.md) | Filters the player's computed move speed after the status-effect multipliers. |
 | [player_equipment_bonus](seams/player_equipment_bonus.md) | Rewrites the equipment bonus lookup's return into a filtered return. |

--- a/docs/MMAPI/MOD_ANATOMY.md
+++ b/docs/MMAPI/MOD_ANATOMY.md
@@ -133,6 +133,38 @@ The queue registration itself is not de-duplicated. Calling `mmapi_register(my_m
 
 A throwing queued function warns rate-limited, attributed to its mod, and the drain continues to the next one. The framework sets the current mod around each call, so hook registrations made inside the function attribute to the mod that queued it.
 
+## User-Facing Text (Localization)
+
+Any text the player sees, such as notification toasts and injected UI strings, should be a **localization key**, not an English literal in your GML. Keys resolve through the engine's localizer, registered strings are real localizer entries that language packs can translate, and every engine-side lookup runs inside MMAPI's [local.get](hooks/local.get.md) filter chain. The pattern shipped mods converged on has three parts:
+
+1. **Strings live in a fiddle file**, `fiddle/mods/<mod>/notifications.toml` (any path works; this is the convention):
+
+   ```toml
+   something_happened = "Something happened!"
+   ```
+
+2. **The file registers for localization**, so ship `localization/l10n.meta.toml` with a `fiddle_renames` entry per string file. **Flat per-file entries only**, since an umbrella directory form (`"mods/my_mod" = ["*"]`) crashes the engine at boot:
+
+   ```toml
+   [asset_properties]
+   	[asset_properties.fiddle_renames]
+   		"mods/my_mod/notifications" = ["*"]
+   ```
+
+   MOMI's TOML merge folds this into the game's `localization/l10n.meta.toml`. Registered text is extracted into engine-minted loc slots and resolved by the real localizer (live-verified by shipped mods).
+
+3. **GML passes the derived key**, the file path minus `.toml`, plus the entry key:
+
+   ```gml
+   create_notification("mods/my_mod/notifications/something_happened");
+   ```
+
+Passing the **key**, not pre-localized text, matters beyond translation. Engine call sites like `create_notification` resolve the key inside the [local_get_dispatch](seams/local_get_dispatch.md) rewrite, so [local.get](hooks/local.get.md) filters can rewrite the text at display time (dynamic token substitution). Mod files are excluded from that rewrite, so pre-localizing in your own code via `ANCHOR.wrap_for_local(local_get(key))` compositions bypasses the whole filter surface; shipped mods hit exactly that failure live before converging on key-passing.
+
+`ANCHOR.wrap_for_local("raw text")` remains the quick form for prototypes and genuinely one-off dynamic strings (vanilla uses it for quest-name toasts), but it is untranslatable and filter-invisible, so keep it out of shipped mods.
+
+One boundary note: t2 conversation text is a separate system, a line's `local` field is inline source text (a fiddle loc key placed there displays raw), and `fiddle_renames` does not apply to `t2/` files.
+
 ## Engine Behavior
 
 The engine behavior every mod must respect.

--- a/docs/MMAPI/QUICK_START.md
+++ b/docs/MMAPI/QUICK_START.md
@@ -88,7 +88,12 @@ function my_first_mod_register_callbacks() {
 // game.day_started is an EVENT: the return value is ignored.
 function my_first_mod_day_started(_ctx) {
     // _ctx contains { total_days }.
-    create_notification("Day " + string(_ctx.total_days) + " begins.");
+    // create_notification takes a LOCALIZATION KEY, not raw text (the engine
+    // runs it through local_get). Wrapping with ANCHOR.wrap_for_local lets raw
+    // text through - fine for a first mod. Shipped mods register real keys
+    // instead (translatable, filter-aware): see RECIPES.md "Show a
+    // Notification" and Mod Anatomy's "User-Facing Text".
+    create_notification(ANCHOR.wrap_for_local("Day " + string(_ctx.total_days) + " begins."));
     mmapi_log_info("my_first_mod", "day started: " + string(_ctx.total_days));
     mmapi_log_flush("my_first_mod"); // make this one-line proof visible immediately
 }

--- a/docs/MMAPI/RECIPES.md
+++ b/docs/MMAPI/RECIPES.md
@@ -29,11 +29,30 @@ ARI.modify_gold(500);   // a negative amount takes gold
 
 ## Show a Notification
 
-```gml
-create_notification("Something happened");
+`create_notification` takes a **localization key**, resolved engine-side through `local_get`. The shipped-mod pattern registers your string and passes the derived key. See the full mechanism in [User-Facing Text](MOD_ANATOMY.md#user-facing-text-localization):
+
+```toml
+# fiddle/mods/my_mod/notifications.toml
+something_happened = "Something happened!"
 ```
 
-Once per real event, not every frame.
+```toml
+# localization/l10n.meta.toml: Flat per-file entries ONLY (the umbrella
+# directory form crashes the engine at boot)
+[asset_properties]
+	[asset_properties.fiddle_renames]
+		"mods/my_mod/notifications" = ["*"]
+```
+
+```gml
+create_notification("mods/my_mod/notifications/something_happened", 60 * 5);
+```
+
+The optional second argument suppresses repeats of the same key for that many frames (`60 * 5` ≈ five seconds). Once per real event, not every frame.
+
+Because the key resolves inside the [local_get_dispatch](seams/local_get_dispatch.md) rewrite, [local.get](hooks/local.get.md) filters can substitute dynamic tokens into the text at display time. Pass the key, never pre-localized text, or the filters never see it.
+
+For throwaway prototypes only: `create_notification(ANCHOR.wrap_for_local("raw text"))` shows unregistered text, it is untranslatable and invisible to filters.
 
 ## Teleport the Player
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -347,7 +347,7 @@ The generated template payload defaults to a site-level `try/catch`, and each di
 - Dispatcher isolation protects one mod from another and applies the kind's failure rule.
 - Site isolation protects the engine from a bad context expression, result assignment, or framework-site assumption around an ordinary dispatch. A `ctx_filter` builds its initial struct before entering its catch, so its field expressions must be safe on their own.
 
-For a simple line op, `try_catch = false` emits that line bare. Existing entries use it only at tested legacy sites. It is not a performance switch; leave it true for new seams unless the exact engine location requires otherwise and the reason is recorded on the seam page.
+For a simple line op, `try_catch = false` emits that line bare. Existing entries use it only at tested sites whose dispatch line cannot fail on its own: a ctx that cannot fail to construct, such as the player delta family's `{ player: self }`. It is not a performance switch, leave it true for new seams unless the exact engine location requires otherwise and the reason is recorded on the seam page.
 
 Check the zero-handler path explicitly:
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -20,7 +20,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 
 The shipped catalog currently declares **88 hooks**, fed by **94 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
-Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks.
+Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks. The derived ones are polls over live state (`room()`, `total_days()`): they lag the change they report, and the first poll of a session only records the baseline, so no event fires for the state a session starts in. Treat them as edge triggers — react to the change, but read the live state at any later decision point rather than caching their ctx (see the warning on [game.room_changed](hooks/game.room_changed.md)).
 
 At install time MOMI also renders the hook declarations into `mmapi_hook_catalog.gml`. That generated file supplies the runtime name, kind, alias, and override-contention tables used by registration checks and introspection. See [The Installed Catalog](HOOKS.md#the-installed-catalog).
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -18,7 +18,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 | `[[engine_fix]]` | A hook-less engine edit. It applies like a text seam but dispatches nothing. |
 | `[[call_rewrite]]` | A tree-wide redirect of direct calls to a native function that has no GML body to seam. |
 
-The shipped catalog currently declares **87 hooks**, fed by **93 seams**, **2 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **87 hooks**, fed by **93 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks.
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -18,7 +18,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 | `[[engine_fix]]` | A hook-less engine edit. It applies like a text seam but dispatches nothing. |
 | `[[call_rewrite]]` | A tree-wide redirect of direct calls to a native function that has no GML body to seam. |
 
-The shipped catalog currently declares **92 hooks**, fed by **99 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **93 hooks**, fed by **100 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks. The derived ones are polls over live state (`room()`, `total_days()`): they lag the change they report, and the first poll of a session only records the baseline, so no event fires for the state a session starts in. Treat them as edge triggers — react to the change, but read the live state at any later decision point rather than caching their ctx (see the warning on [game.room_changed](hooks/game.room_changed.md)).
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -18,7 +18,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 | `[[engine_fix]]` | A hook-less engine edit. It applies like a text seam but dispatches nothing. |
 | `[[call_rewrite]]` | A tree-wide redirect of direct calls to a native function that has no GML body to seam. |
 
-The shipped catalog currently declares **87 hooks**, fed by **93 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **88 hooks**, fed by **94 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks.
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -18,7 +18,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 | `[[engine_fix]]` | A hook-less engine edit. It applies like a text seam but dispatches nothing. |
 | `[[call_rewrite]]` | A tree-wide redirect of direct calls to a native function that has no GML body to seam. |
 
-The shipped catalog currently declares **88 hooks**, fed by **94 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **92 hooks**, fed by **99 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_started`, `game.room_changed`, and `game.title_entered` are the current runtime-provided hooks. The derived ones are polls over live state (`room()`, `total_days()`): they lag the change they report, and the first poll of a session only records the baseline, so no event fires for the state a session starts in. Treat them as edge triggers — react to the change, but read the live state at any later decision point rather than caching their ctx (see the warning on [game.room_changed](hooks/game.room_changed.md)).
 

--- a/docs/MMAPI/hooks/fishing.should_reel.md
+++ b/docs/MMAPI/hooks/fishing.should_reel.md
@@ -1,0 +1,46 @@
+# Hook: fishing.should_reel
+
+Change whether the player reels while waiting for a fish.
+
+`fishing.should_reel` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires every step of the player fishing FSM's `FishingState.Wait`, after bite notification handling and before the retract sound, caught/missed handling, and Reel transitions. The filtered value is whether the normal charged or repeated tool input requested a reel. ctx is `{ bite_active }`, where `bite_active` is true while `FISHING.bite_timer` is positive. Return a replacement boolean, or `undefined` to keep the current value.
+
+The final true value runs the complete vanilla reel block. While `bite_active` is true that block catches the fish, fills the fishing FSM's celebration data, clears the bite timer, and starts the player and bobber Reel states. Without an active bite it takes the normal Missed path. A final false value remains in Wait, even when the player supplied reel input.
+
+| | |
+| --- | --- |
+| **Fires** | Every step of `FishingState.Wait`, after bite notification handling and before the reel block. |
+| **Value** | Whether the normal tool inputs requested a reel this frame. |
+| **ctx** | `{ bite_active }` |
+| **Kind contract** | The callback receives the current boolean and returns a replacement, or `undefined` to keep the current value. |
+
+This is a hot hook while the player waits for a fish. Put the cheapest test first and avoid logging on every dispatch.
+
+## Usage
+
+```gml
+// fishing.should_reel is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function auto_reel_fishing_should_reel(_value, _ctx) {
+    // Preserve ordinary input, but request a reel as soon as a bite is active.
+    if (_ctx.bite_active == true) return true;
+    return undefined;
+}
+
+// Inside your latched register function (see Mod Anatomy):
+mmapi_filter("fishing.should_reel", auto_reel_fishing_should_reel);
+```
+
+Returning false can suppress reeling, including a manual reel request. Return `undefined`, not false, when the handler has no opinion.
+
+## Engine Wiring
+
+- Seam [`fishing_should_reel`](../seams/fishing_should_reel.md) dispatches from `gml/scripts/Player/AriFsm.gml`, replacing the `FishingState.Wait` input gate with a filtered boolean before the original reel block.
+
+## See Also
+
+- [fsm.transition](fsm.transition.md) - Observe, redirect, or cancel the state transitions that happen after the reel decision.
+- [input.check_value_id](input.check_value_id.md) - Remap an input id at the engine's input-value lookup rather than changing this fishing decision.

--- a/docs/MMAPI/hooks/game.room_changed.md
+++ b/docs/MMAPI/hooks/game.room_changed.md
@@ -6,7 +6,7 @@ Know when the player has landed in a different room.
 
 ## Contract
 
-Fires from the begin_step derived-events poll when `room()` changes, after `room_start` has already run. ctx is `{ previous, current }` (`gm_room` values). Observation only: to change room content as it loads, use the in-file seams ([dungeon.floor_enter](dungeon.floor_enter.md) and the room transition events) instead.
+Fires from the begin_step derived-events poll when `room()` changes, after `room_start` has already run. ctx is `{ previous, current }` (`gm_room` values). Observation only: to change room content as it loads, use the in-file seams ([dungeon.floor_enter](dungeon.floor_enter.md) and the room transition events) instead. Do not cache `ctx.current` for a later decision — see the warning below.
 
 | | |
 | --- | --- |
@@ -21,6 +21,9 @@ Fires from the begin_step derived-events poll when `room()` changes, after `room
 
 > [!NOTE]
 > This event fires after the fact: begin_step runs after `room_start`, so the new room is already set up when your handler runs. The first poll of a session only records the current room as the baseline. No event fires for the room the session starts in.
+
+> [!WARNING]
+> Do not derive state from this event. Caching `ctx.current` in your runtime and reading the cache at a later decision point goes stale three distinct ways: the poll lags the real transition by a frame or more; a session that loads straight into a room gets no event, so the cache stays empty until the next change; and the ctx values are `gm_room` **assets**, not name strings — an `is_string(ctx.current)` check silently drops them. Each of these has shipped as a real bug in ported mods whose legacy versions hooked the room-change function itself, where handler-time caches were sound; this event is a lagging echo of that change, not the change. Read `room()` live at the point of use instead (`asset_to_string(room())` for the name), and treat this event as an **edge trigger** only — react to a transition, never record it. When you need request-time semantics — knowing or changing where a transition is going before it happens — use [game.room_transition_pre](game.room_transition_pre.md).
 
 ## Usage
 

--- a/docs/MMAPI/hooks/game.room_transition_pre.md
+++ b/docs/MMAPI/hooks/game.room_transition_pre.md
@@ -57,5 +57,5 @@ mmapi_on("game.room_transition_pre", taxi_detour_game_room_transition_pre);
 ## See Also
 
 - [game.room_transition_post](game.room_transition_post.md) - This is the end of the same transition, with the same ctx struct re-read from the live itinerary.
-- [game.room_changed](game.room_changed.md) - This is the after-the-fact derived event, which fires once the room has actually changed.
+- [game.room_changed](game.room_changed.md) - This is the after-the-fact derived event, which fires once the room has actually changed. It is a lagging observation, never a state source; this hook is where request-time semantics live.
 - [dungeon.floor_enter](dungeon.floor_enter.md) - This is the dungeon-side entry bracket, for changing dungeon floor content as it loads.

--- a/docs/MMAPI/hooks/player.essence_delta.md
+++ b/docs/MMAPI/hooks/player.essence_delta.md
@@ -1,0 +1,51 @@
+# Hook: player.essence_delta
+
+Change every essence gain or spend before it applies.
+
+`player.essence_delta` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.modify_essence()`, before the delta is applied. The filtered value is the signed essence delta. The ctx is `{ player }`. Return the replacement delta (`0` makes the call a no-op), or `undefined` to keep the current value.
+
+The seam floors the filtered result at `-essence`, so the total never goes negative. Absolute sets (save load, new game, debug) do not route through `modify_essence` and never fire this hook.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.modify_essence(amount_to_add)`, before the delta is applied. |
+| **Value** | The signed essence delta: gains positive, spends negative. |
+| **ctx** | `{ player }` |
+| **Kind contract** | The callback receives the current value and returns a replacement, or `undefined` to keep the current value. The seam floors the result at `-essence`. |
+
+### The ctx struct
+
+- `player` - the `Ari` struct whose essence is changing.
+
+## Usage
+
+```gml
+// player.essence_delta is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function essence_magnet_player_essence_delta(_value, _ctx) {
+    // _value is the signed essence delta: positive = gain, negative = spend.
+    // The seam floors whatever you return at -essence, so an inflated spend
+    // bottoms out at zero total.
+    // _ctx is { player }.
+    //   .player - the Ari struct whose essence is changing.
+    if (_value == undefined) return undefined; // test undefined BEFORE anything else
+    if (_value > 0) return _value * 2; // double every essence gain
+    return undefined; // undefined = keep spends unchanged
+}
+
+mmapi_filter("player.essence_delta", essence_magnet_player_essence_delta);
+```
+
+## Engine Wiring
+
+- Seam [`player_essence_delta`](../seams/player_essence_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `modify_essence(amount_to_add)`, filtering `amount_to_add` and flooring the result at `-essence` before `set_essence` runs.
+
+## See Also
+
+- [player.gold_delta](player.gold_delta.md) - The similar filter point for gold.
+- [player.mana_delta](player.mana_delta.md) - The similar filter point for mana.
+- [player.health_delta](player.health_delta.md) - The similar filter point for health.

--- a/docs/MMAPI/hooks/player.gold_delta.md
+++ b/docs/MMAPI/hooks/player.gold_delta.md
@@ -1,0 +1,50 @@
+# Hook: player.gold_delta
+
+Change every gold gain or spend before it applies.
+
+`player.gold_delta` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.modify_gold()`, before the delta is applied. The filtered value is the signed gold delta. The ctx is `{ player }`. Return the replacement delta (`0` makes the call a no-op), or `undefined` to keep the current value.
+
+End-of-day shipping income routes through here too, as one delta when the earnings pay out. Absolute sets (save load, new game, debug) do not route through `modify_gold` and never fire this hook.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.modify_gold(amount_to_add)`, before the delta is applied. |
+| **Value** | The signed gold delta: earnings positive, spends negative. |
+| **ctx** | `{ player }` |
+| **Kind contract** | The callback receives the current value and returns a replacement, or `undefined` to keep the current value. |
+
+### The ctx struct
+
+- `player` - the `Ari` struct whose gold is changing.
+
+## Usage
+
+```gml
+// player.gold_delta is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function hard_times_player_gold_delta(_value, _ctx) {
+    // _value is the signed gold delta: positive = earnings, negative = spend.
+    // A store checkout is one negative delta of the whole basket total.
+    // _ctx is { player }.
+    //   .player - the Ari struct whose gold is changing.
+    if (_value == undefined) return undefined; // test undefined BEFORE anything else
+    if (_value > 0) return _value * 0.5; // half earnings (set_gold truncates the total)
+    return undefined; // undefined = keep spends unchanged
+}
+
+mmapi_filter("player.gold_delta", hard_times_player_gold_delta);
+```
+
+## Engine Wiring
+
+- Seam [`player_gold_delta`](../seams/player_gold_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `modify_gold(amount_to_add)`, filtering `amount_to_add` before the engine's `set_gold` floors and applies the total.
+
+## See Also
+
+- [player.essence_delta](player.essence_delta.md) - The filter point for essence.
+- [player.mana_delta](player.mana_delta.md) - The filter point for mana.
+- [store.item_added](store.item_added.md) - Know each item as it lands in the basket this checkout total comes from.

--- a/docs/MMAPI/hooks/player.health_delta.md
+++ b/docs/MMAPI/hooks/player.health_delta.md
@@ -48,4 +48,5 @@ mmapi_filter("player.health_delta", iron_constitution_player_health_delta);
 
 - [player.incoming_damage](player.incoming_damage.md) - Filter combat damage specifically, before it reaches `modify_health`.
 - [player.stamina_delta](player.stamina_delta.md) - This is the same filter point for stamina.
+- [player.essence_delta](player.essence_delta.md) - The same filter family: essence, gold, mana, and skill XP each have theirs.
 - [player.heal_vfx](player.heal_vfx.md) - Veto the heal sparkle without touching the heal.

--- a/docs/MMAPI/hooks/player.mana_delta.md
+++ b/docs/MMAPI/hooks/player.mana_delta.md
@@ -1,0 +1,55 @@
+# Hook: player.mana_delta
+
+Change every mana gain or spend before it applies.
+
+`player.mana_delta` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.modify_mana()`, before the delta is applied. The filtered value is the signed mana delta. The ctx is `{ player }`. Return the replacement delta (`0` makes the call a no-op), or `undefined` to keep the current value.
+
+Item restores, such as the mana potion, fire this hook too. Cutscenes and other absolute sets do not.
+
+> [!TIP]
+> Composes with [spells.cost](spells.cost.md): a cast's deduction arrives here as the negative of the already-filtered cost. Prefer `spells.cost` for spell pricing. It keeps the menu display, the can-cast check, and the deduction in agreement. Use this hook for everything else.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.modify_mana(amount_to_add)`, before the delta is applied. |
+| **Value** | The signed mana delta: deductions negative, restores positive. |
+| **ctx** | `{ player }` |
+| **Kind contract** | The callback receives the current value and returns a replacement, or `undefined` to keep the current value. |
+
+### The ctx struct
+
+- `player` - the `Ari` struct whose mana is changing.
+
+## Usage
+
+```gml
+// player.mana_delta is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function overcharged_player_mana_delta(_value, _ctx) {
+    // _value is the signed mana delta: negative = deduction, positive = restore.
+    // Cast deductions arrive as the negative of the (spells.cost-filtered) cost;
+    // prefer spells.cost for pricing so the menu and deduction agree.
+    // _ctx is { player }.
+    //   .player - the Ari struct whose mana is changing.
+    if (_value == undefined) return undefined; // test undefined BEFORE anything else
+    if (_value > 0) return _value * 2; // double every restore (set_mana clamps at mana_max)
+    return undefined; // undefined = keep deductions unchanged
+}
+
+mmapi_filter("player.mana_delta", overcharged_player_mana_delta);
+```
+
+## Engine Wiring
+
+- Seam [`player_mana_delta`](../seams/player_mana_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `modify_mana(amount_to_add)`, filtering `amount_to_add` before the engine's `set_mana` clamps and applies the total.
+- Seam [`player_mana_item_delta`](../seams/player_mana_item_delta.md) dispatches nothing itself: it reroutes the mana potion's direct `set_mana` call in `gml/scripts/Player/AriFsm.gml` through `modify_mana`, so item restores reach the filter above.
+
+## See Also
+
+- [spells.cost](spells.cost.md) - Change a spell's price instead of the deduction it produces.
+- [player.essence_delta](player.essence_delta.md) - The similar filter point for essence.
+- [player.stamina_delta](player.stamina_delta.md) - The similar filter point for stamina.

--- a/docs/MMAPI/hooks/player.renown_delta.md
+++ b/docs/MMAPI/hooks/player.renown_delta.md
@@ -1,0 +1,55 @@
+# Hook: player.renown_delta
+
+Change every renown gain before it applies, or turn it into a deduction.
+
+`player.renown_delta` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.modify_renown()`, before the delta is applied. The filtered value is the renown delta. The ctx is `{ player }`. Return the replacement delta (`0` makes the call a no-op), or `undefined` to keep the current value.
+
+Renown gains queue as pending entries during the day - quest completions, museum donations, the day's shipping gold - and drain at day rollover, one `modify_renown` call per entry. That drain is the engine's only gameplay caller, so this hook fires once per pending entry as the new day starts. Absolute sets (debug, test suite, new game) do not route through `modify_renown` and never fire this hook.
+
+`set_renown` clamps the resulting total to `[0, max renown]`, so any replacement is safe. A negative replacement lowers renown and the computed level, plays no celebration, and never revokes already-granted level rewards. A gain that crosses several levels grants each crossed level's reward.
+
+> [!TIP]
+> The end-of-day menu tallies the pending entries before the drain, so its renown-earned figure shows the unfiltered values. The filter applies afterward, as the entries land.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.modify_renown(amount_to_add)`, before the delta is applied. |
+| **Value** | The renown delta. Vanilla deltas are always gains; a negative replacement deducts. |
+| **ctx** | `{ player }` |
+| **Kind contract** | The callback receives the current value and returns a replacement, or `undefined` to keep the current value. |
+
+### The ctx struct
+
+- `player` - the `Ari` struct whose renown is changing.
+
+## Usage
+
+```gml
+// player.renown_delta is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function town_favorite_player_renown_delta(_value, _ctx) {
+    // _value is the renown delta: one pending entry's worth, drained at day
+    // rollover. Negative deducts; set_renown clamps the total at zero.
+    // _ctx is { player }.
+    //   .player - the Ari struct whose renown is changing.
+    if (_value == undefined) return undefined; // test undefined BEFORE anything else
+    if (_value > 0) return _value * 2; // double every renown gain
+    return undefined; // undefined = keep the game's value
+}
+
+mmapi_filter("player.renown_delta", town_favorite_player_renown_delta);
+```
+
+## Engine Wiring
+
+- Seam [`player_renown_delta`](../seams/player_renown_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `modify_renown(amount_to_add)`, filtering `amount_to_add` before the engine's `set_renown` clamps and applies the total.
+
+## See Also
+
+- [player.xp_delta](player.xp_delta.md) - The similar filter point for skill XP.
+- [player.gold_delta](player.gold_delta.md) - The filter point for the shipping gold that becomes a renown entry.
+- [npc.heart_points](npc.heart_points.md) - The equivalent delta filter for villager hearts.

--- a/docs/MMAPI/hooks/player.stamina_delta.md
+++ b/docs/MMAPI/hooks/player.stamina_delta.md
@@ -45,5 +45,6 @@ mmapi_filter("player.stamina_delta", tireless_player_stamina_delta);
 
 ## See Also
 
-- [player.health_delta](player.health_delta.md) - This is the same filter point for health.
+- [player.health_delta](player.health_delta.md) - The similar filter point for health.
+- [player.mana_delta](player.mana_delta.md) - The similar filter point for mana.
 - [player.move_speed](player.move_speed.md) - Change the player's move speed after every engine modifier.

--- a/docs/MMAPI/hooks/player.xp_delta.md
+++ b/docs/MMAPI/hooks/player.xp_delta.md
@@ -1,0 +1,56 @@
+# Hook: player.xp_delta
+
+Change every skill XP gain before it applies, or turn it into a deduction.
+
+`player.xp_delta` is a **filter** hook. Register a callback with `mmapi_filter`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.gain_xp(skill, xp, silent)`, before the XP is applied. The filtered value is the XP delta. ctx is `{ player, skill, silent }`; `skill` is the `Skill.*` enum id, so one handler covers every skill and can branch on the one it cares about. Return the replacement delta, or `undefined` to keep the current value.
+
+A negative delta genuinely deducts XP and can lower the skill's level. The seam makes that safe: it floors the filtered result at `-skill_xp[skill]`, so the running total never goes negative.
+
+The engine's own cap at `MAX_SKILL_LEVEL_COSTS` still applies after the filter, and already-granted level rewards are not revoked by leveling down. A mod that wants to deduct XP outright (rather than transform an engine gain) calls `ARI.gain_xp(skill, -amount)` directly. The deduction routes through this filter and the same floor.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.gain_xp(skill, xp, silent)`, before the XP is applied. |
+| **Value** | The XP delta. Vanilla deltas are always gains; a negative replacement deducts. |
+| **ctx** | `{ player, skill, silent }` |
+| **Kind contract** | The callback receives the current value and returns a replacement, or `undefined` to keep the current value. The seam floors the result at `-skill_xp[skill]`. |
+
+### The ctx struct
+
+- `player` - the `Ari` struct gaining the XP.
+- `skill` - the `Skill.*` enum id of the skill the XP applies to.
+- `silent` - the `silent` flag `gain_xp` received: whether the engine caller asked to skip the level-up celebration.
+
+## Usage
+
+```gml
+// player.xp_delta is a FILTER: you receive (value, ctx) and return a
+// replacement, or undefined to keep the game's value.
+function battle_scholar_player_xp_delta(_value, _ctx) {
+    // _value is the XP delta. Negative deducts; the seam floors your return
+    // at -skill_xp[skill], so the total never goes below zero.
+    // _ctx is { player, skill, silent }.
+    //   .player - the Ari struct gaining the XP.
+    //   .skill  - the Skill.* enum id the XP applies to.
+    //   .silent - whether the caller asked to skip the celebration.
+    if (_value == undefined) return undefined; // test undefined BEFORE anything else
+    if (_ctx.skill == Skill.Combat) return _value * 2; // double Combat XP only
+    return undefined; // undefined = keep every other skill unchanged
+}
+
+mmapi_filter("player.xp_delta", battle_scholar_player_xp_delta);
+```
+
+## Engine Wiring
+
+- Seam [`player_xp_delta`](../seams/player_xp_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `gain_xp(skill, xp, silent)`, filtering `xp` and flooring the result before the engine's capped add. The same edit narrows the level celebration from any level change to a genuine gain.
+
+## See Also
+
+- [player.essence_delta](player.essence_delta.md) - The similar filter shape for essence change.
+- [npc.heart_points](npc.heart_points.md) - The equivalent delta filter for villager hearts.
+- [animal.heart_points](animal.heart_points.md) - The equivalent delta filter for barn animals.

--- a/docs/MMAPI/hooks/spells.cost.md
+++ b/docs/MMAPI/hooks/spells.cost.md
@@ -49,4 +49,5 @@ mmapi_filter("spells.cost", mana_miser_spells_cost);
 
 - [spells.can_cast](spells.can_cast.md) - Take over the whole can-cast decision instead of just its mana term.
 - [spells.cast](spells.cast.md) - Replace the cast itself. A consumed cast still pays this cost.
+- [player.mana_delta](player.mana_delta.md) - Filter the mana deduction itself, after this cost filter has run.
 - [ui.sprite](ui.sprite.md) - Swap the spell card backplate in the same menu.

--- a/docs/MMAPI/seams/fishing_should_reel.md
+++ b/docs/MMAPI/seams/fishing_should_reel.md
@@ -1,0 +1,33 @@
+# Seam: fishing_should_reel
+
+Filters the fishing Wait state's reel decision before the complete vanilla reel block.
+
+`fishing_should_reel` is a **text seam** (`anchor` + `replace`). It feeds [fishing.should_reel](../hooks/fishing.should_reel.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/Player/AriFsm.gml` |
+| **Locator** | text anchor on the reel-input condition inside `FishingState.Wait`, including the following `fishing_sfx` line |
+| **Op** | text (`anchor` + `replace`) |
+| **Feeds** | [`fishing.should_reel`](../hooks/fishing.should_reel.md) |
+| **Value filtered** | the boolean OR of `UseToolCharged` and `UseToolRepeated` |
+| **ctx built** | `{ bite_active: FISHING.bite_timer > 0 }` |
+| **Marker** | `mmapi_fishing_run_should_reel_filters` |
+
+## The Edit
+
+Pristine `AriFsm.gml` uses the same tool-input expression in both `FishingState.Windup` and `FishingState.Wait`. The locator includes Wait's following `fishing_sfx` assignment so the anchor identifies exactly one site.
+
+The replacement evaluates the pristine input expression once into `__mmapi_fishing_should_reel`, filters that boolean through `mmapi_apply_filters("fishing.should_reel", ..., { bite_active: FISHING.bite_timer > 0 })`, then uses the final value as the original `if` condition. A site-level catch leaves the captured input result unchanged if context construction, dispatch, or assignment fails.
+
+A final true value enters the original block without replacing any of it: the retract sound, Caught/Missed notification, celebration/essence/size blackboard writes, bite-timer reset, and player and bobber Reel transitions remain engine-owned. A final false value stays in Wait. This lets a mod request an automatic catch while the bite timer is active without reproducing the catch pipeline.
+
+With zero handlers the filter returns the captured input result unchanged, so the seam is behaviorally identical to pristine. The dispatch runs every frame while the nested fishing FSM waits for a fish, so handlers should keep their first test cheap.
+
+## See Also
+
+- [fishing.should_reel](../hooks/fishing.should_reel.md) - This is the hook this seam dispatches.
+- [fsm_transition](fsm_transition.md) - Filters the later state-transition requests shared by the player, fishing sub-machine, fish, and bobber.
+- [input_check_value_id](input_check_value_id.md) - Filters input ids at the general input lookup rather than this fishing-specific decision.

--- a/docs/MMAPI/seams/game_step_begin_installs.md
+++ b/docs/MMAPI/seams/game_step_begin_installs.md
@@ -25,4 +25,5 @@ Every runtime-provided hook and every per-frame mod tick ultimately runs because
 
 - [Mod Anatomy](../MOD_ANATOMY.md) - This page describes the boot / first-drain / every-frame lifecycle this edit roots.
 - [camera_culls_processed](camera_culls_processed.md) - This is a seam whose timing story is defined relative to this begin_step tick.
-- [shroom_puddle_mask](shroom_puddle_mask.md) - This is the catalog's other engine fix.
+- [shroom_puddle_mask](shroom_puddle_mask.md) - This is another of the catalog's engine fixes, a beta-wiring correction.
+- [statue_hp_death_sweep](statue_hp_death_sweep.md) - This is another of the catalog's engine fixes, the griffin statue's missing death check.

--- a/docs/MMAPI/seams/player_essence_delta.md
+++ b/docs/MMAPI/seams/player_essence_delta.md
@@ -1,0 +1,31 @@
+# Seam: player_essence_delta
+
+Filters the signed essence delta at the top of `Ari.modify_essence()`, floored so the total never goes negative.
+
+`player_essence_delta` is a **text seam** (`anchor` + `replace`). It feeds [player.essence_delta](../hooks/player.essence_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | text anchor on the whole of `modify_essence(amount_to_add)`, a one-line body |
+| **Op** | text (`anchor` + `replace`) |
+| **Feeds** | [`player.essence_delta`](../hooks/player.essence_delta.md) |
+| **Value filtered** | `amount_to_add` - the signed essence delta |
+| **ctx built** | `{ player: self }` |
+| **Marker** | `mmapi_player_run_essence_delta_filters` |
+
+## The Edit
+
+A text seam rather than a template one, because the dispatch carries its own floor. The replacement runs `mmapi_apply_filters("player.essence_delta", amount_to_add, { player: self })` in a try/catch, and only adopts the result when it is numeric (`is_real` or `is_int64`); the adopted value is floored at `-self.essence` before the pristine `set_essence(self.essence + amount_to_add)` line runs.
+
+The floor is the point of the seam. `set_essence` has no lower clamp, and it carries an `assert(essence >= 0)` on the *pre-change* value - so a handler that overdraws essence does not crash at the overdraw, it arms a crash that fires on the next essence change, far from the handler that caused it. The floor makes that state unreachable. It never binds on engine values: every vanilla spend is affordability-gated before `modify_essence` is called, so with zero handlers the edit is behaviorally equivalent to pristine. The type guard serves the same defensive role as the defensive re-reads in the struct-filter seams: a non-numeric handler return is dropped instead of crashing the arithmetic below.
+
+`modify_essence` funnels every gameplay essence change - morsel pickups, item gains, ritual refunds, shrine offerings, craft costs - so one edit filters them all. Absolute sets (save load, new game, debug) write the field directly and never pass through here.
+
+## See Also
+
+- [player.essence_delta](../hooks/player.essence_delta.md) - This is the hook this seam dispatches.
+- [player_xp_delta](player_xp_delta.md) - This seam's sibling: the other delta filter that carries its own floor.
+- [player_stamina_delta](player_stamina_delta.md) - The template-form shape this family started from.

--- a/docs/MMAPI/seams/player_gold_delta.md
+++ b/docs/MMAPI/seams/player_gold_delta.md
@@ -1,0 +1,29 @@
+# Seam: player_gold_delta
+
+Filters the signed gold delta at the top of `Ari.modify_gold()`.
+
+`player_gold_delta` is a **template seam** (`op = "filter"`). It feeds [player.gold_delta](../hooks/player.gold_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | pristine context: the head of `modify_gold(amount_to_add)`, before the `set_gold` line |
+| **Op** | `filter` (`try_catch = false`) |
+| **Feeds** | [`player.gold_delta`](../hooks/player.gold_delta.md) |
+| **Value filtered** | `amount_to_add` - the signed gold delta |
+| **ctx built** | `{ player: self }` |
+| **Marker** | `mmapi_player_run_gold_delta_filters` |
+
+## The Edit
+
+The generated dispatch lands at the head of `Ari.modify_gold()` and reassigns its argument: `amount_to_add = mmapi_apply_filters("player.gold_delta", amount_to_add, { player: self })`. The engine then runs `set_gold(self.gold + amount_to_add)`, which floors the resulting total at `0` and truncates fractions - so unlike its essence sibling, this seam needs no floor of its own. An overdrawing replacement bottoms out at broke, exactly as a vanilla overdraw would.
+
+This seam sets `try_catch = false`: the dispatch is a direct assignment, not wrapped in the uniform try/catch shape. The filter registry's own per-handler isolation still applies. A throwing handler is contained by the registry, not by the seam. `modify_gold` funnels every gameplay gold change - sales, rewards, grants, purchases, fees, craft costs, the end-of-day shipping payout - so one edit filters them all. Absolute sets (save load, new game, debug) write through `set_gold` directly and never pass through here.
+
+## See Also
+
+- [player.gold_delta](../hooks/player.gold_delta.md) - This is the hook this seam dispatches.
+- [player_essence_delta](player_essence_delta.md) - The same funnel for essence, where the engine has no floor and the seam supplies one.
+- [player_mana_delta](player_mana_delta.md) - This seam is the same shape on `modify_mana()`.

--- a/docs/MMAPI/seams/player_mana_delta.md
+++ b/docs/MMAPI/seams/player_mana_delta.md
@@ -1,0 +1,29 @@
+# Seam: player_mana_delta
+
+Filters the signed mana delta at the top of `Ari.modify_mana()`.
+
+`player_mana_delta` is a **template seam** (`op = "filter"`). It feeds [player.mana_delta](../hooks/player.mana_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | pristine context: the head of `modify_mana(amount_to_add)`, before the `get_mana`/`set_mana` lines |
+| **Op** | `filter` (`try_catch = false`) |
+| **Feeds** | [`player.mana_delta`](../hooks/player.mana_delta.md) |
+| **Value filtered** | `amount_to_add` - the signed mana delta |
+| **ctx built** | `{ player: self }` |
+| **Marker** | `mmapi_player_run_mana_delta_filters` |
+
+## The Edit
+
+The generated dispatch lands at the head of `Ari.modify_mana()` and reassigns its argument: `amount_to_add = mmapi_apply_filters("player.mana_delta", amount_to_add, { player: self })`. The engine then runs `set_mana(o + amount_to_add)`, which clamps the resulting total to `[0, mana_max]` - so the seam needs no floor of its own and any replacement is safe.
+
+This seam sets `try_catch = false`: the dispatch is a direct assignment, not wrapped in the uniform try/catch shape. The filter registry's own per-handler isolation still applies. A throwing handler is contained by the registry, not by the seam. `modify_mana` carries the cast-state deductions (already filtered by [spells.cost](../hooks/spells.cost.md)), the new-day point, date bonuses, and dungeon pickups; the one gameplay delta that bypasses it - the mana potion - is rerouted here by the companion seam [player_mana_item_delta](player_mana_item_delta.md). Cutscene absolute sets and save load call `set_mana` directly and never pass through.
+
+## See Also
+
+- [player.mana_delta](../hooks/player.mana_delta.md) - This is the hook this seam dispatches.
+- [player_mana_item_delta](player_mana_item_delta.md) - The companion reroute that brings the mana potion into this funnel.
+- [spells_cost_fsm_default](spells_cost_fsm_default.md) - One of the cost filters whose output arrives here as a deduction.

--- a/docs/MMAPI/seams/player_mana_item_delta.md
+++ b/docs/MMAPI/seams/player_mana_item_delta.md
@@ -1,0 +1,29 @@
+# Seam: player_mana_item_delta
+
+Reroutes the mana potion's direct `set_mana` call through `modify_mana`, so item restores fire the mana filter.
+
+`player_mana_item_delta` is a **text seam** (`anchor` + `replace`). It feeds [player.mana_delta](../hooks/player.mana_delta.md), though it dispatches nothing itself - the dispatch lives in [player_mana_delta](player_mana_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/Player/AriFsm.gml` |
+| **Locator** | text anchor on the mana potion's consume line, `ARI.set_mana(ARI.mana_current + ...mana_modifier)` |
+| **Op** | text (`anchor` + `replace`) |
+| **Feeds** | [`player.mana_delta`](../hooks/player.mana_delta.md) (via [`player_mana_delta`](player_mana_delta.md)) |
+| **Value filtered** | none - this edit dispatches nothing itself |
+| **ctx built** | none |
+| **Marker** | `mmapi_player_mana_item_delta` |
+
+## The Edit
+
+A one-line reroute. When the player drinks a mana potion, pristine code credits the restore with `ARI.set_mana(ARI.mana_current + self.live_item.prototype.mana_modifier)` - the only gameplay-delta mana change in the engine that bypasses `modify_mana`. The replacement is `ARI.modify_mana(self.live_item.prototype.mana_modifier)`.
+
+The reroute is behavior-identical: `modify_mana(x)` is literally `set_mana(get_mana() + x)`, and `get_mana()` returns `mana_current`. What it buys is coverage - the potion's restore now enters the same funnel every other mana delta uses, so a [player.mana_delta](../hooks/player.mana_delta.md) handler sees item restores without a second dispatch site. This is the same companion-edit pattern as [dialogue_speaker_ctx_arg](dialogue_speaker_ctx_arg.md): an edit that dispatches nothing of its own, existing only so its sibling's dispatch sees everything.
+
+## See Also
+
+- [player.mana_delta](../hooks/player.mana_delta.md) - This is the hook this reroute feeds.
+- [player_mana_delta](player_mana_delta.md) - This is the dispatch the rerouted call now reaches.
+- [dialogue_speaker_ctx_arg](dialogue_speaker_ctx_arg.md) - The other dispatch-less companion edit in the catalog.

--- a/docs/MMAPI/seams/player_renown_delta.md
+++ b/docs/MMAPI/seams/player_renown_delta.md
@@ -1,0 +1,29 @@
+# Seam: player_renown_delta
+
+Filters the renown delta at the top of `Ari.modify_renown()`.
+
+`player_renown_delta` is a **template seam** (`op = "filter"`). It feeds [player.renown_delta](../hooks/player.renown_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | pristine context: the head of `modify_renown(amount_to_add)`, before the `set_renown` line |
+| **Op** | `filter` (`try_catch = false`) |
+| **Feeds** | [`player.renown_delta`](../hooks/player.renown_delta.md) |
+| **Value filtered** | `amount_to_add` - the renown delta |
+| **ctx built** | `{ player: self }` |
+| **Marker** | `mmapi_player_run_renown_delta_filters` |
+
+## The Edit
+
+The generated dispatch lands at the head of `Ari.modify_renown()` and reassigns its argument: `amount_to_add = mmapi_apply_filters("player.renown_delta", amount_to_add, { player: self })`. The engine then runs `set_renown(self.renown + amount_to_add)`, which floors and clamps the resulting total to `[0, max renown]`, so the seam needs no floor of its own and any replacement is safe. `set_renown` grants level rewards only on the way up (a non-positive level change returns before the reward loop), so a deducting filter lowers the total and the computed level without revoking anything or playing a celebration.
+
+This seam sets `try_catch = false`. The dispatch is a direct assignment, not wrapped in the uniform try/catch shape. The filter registry's own per-handler isolation still applies. A throwing handler is contained by the registry, not by the seam. `modify_renown` has exactly one gameplay caller - the `on_new_day` drain of `pending_renown_entries`, one call per entry (quest completions, museum donations, the prior day's shipping gold) - so the filter sees every renown gain as it lands at day rollover. Direct `set_renown` calls (incuding a new game) are absolutes, so none pass through here.
+
+## See Also
+
+- [player.renown_delta](../hooks/player.renown_delta.md) - This is the hook this seam dispatches.
+- [player_gold_delta](player_gold_delta.md) - This seam is the same shape on `modify_gold()`.
+- [player_xp_delta](player_xp_delta.md) - The other progression delta, where the engine has no floor and the seam supplies one.

--- a/docs/MMAPI/seams/player_stamina_delta.md
+++ b/docs/MMAPI/seams/player_stamina_delta.md
@@ -26,4 +26,4 @@ This seam sets `try_catch = false`: the dispatch is a direct assignment, not wra
 
 - [player.stamina_delta](../hooks/player.stamina_delta.md) - This is the hook this seam dispatches.
 - [player_health_delta](player_health_delta.md) - This seam is the same shape on `modify_health()`.
-- [player_move_speed](player_move_speed.md) - This seam is the third of `Ari.gml`'s direct-dispatch stat filters.
+- [player_move_speed](player_move_speed.md) - This seam is another of `Ari.gml`'s direct-dispatch stat filters, alongside [player_gold_delta](player_gold_delta.md) and [player_mana_delta](player_mana_delta.md).

--- a/docs/MMAPI/seams/player_xp_delta.md
+++ b/docs/MMAPI/seams/player_xp_delta.md
@@ -1,0 +1,32 @@
+# Seam: player_xp_delta
+
+Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and narrows the level celebration to genuine gains.
+
+`player_xp_delta` is a **text seam** (`anchor` + `replace`). It feeds [player.xp_delta](../hooks/player.xp_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | text anchor spanning `gain_xp(skill, xp, silent)` from its head through the level-celebration condition |
+| **Op** | text (`anchor` + `replace`) |
+| **Feeds** | [`player.xp_delta`](../hooks/player.xp_delta.md) |
+| **Value filtered** | `xp` - the XP delta |
+| **ctx built** | `{ player: self, skill: skill, silent: silent }` |
+| **Marker** | `mmapi_player_run_xp_delta_filters` |
+
+## The Edit
+
+One anchor, two changes, both unreachable in vanilla:
+
+1. **The filter, with its floor.** At the head of `gain_xp()`, the replacement runs `mmapi_apply_filters("player.xp_delta", xp, { player: self, skill: skill, silent: silent })` in a try/catch, adopts the result only when it is numeric (`is_real` or `is_int64`), and floors the adopted value at `-self.skill_xp[skill]`. The engine's capped add - `min(skill_xp[skill] + xp, MAX_SKILL_LEVEL_COSTS[skill])` - then runs on the filtered delta. The floor matters because the engine has no lower clamp of its own and `skill_xp_to_level()` reads a negative total as level `-1`; floored at zero total, the computed level bottoms out at 1, since levels 0 and 1 cost 0 XP.
+2. **The celebration narrows.** Pristine celebrates any level change: `if !silent && old_skill_level != ARI.level(skill)` plays the LevelUp sound and spawns the skill dingaling. The replacement changes `!=` to `<`, so a level *down* - reachable only through this hook's negative deltas - passes silently instead of playing a level-up fanfare.
+
+With zero handlers both changes are behaviorally equivalent to pristine: every vanilla delta is non-negative, so the floor never binds and the `<` condition agrees with `!=` everywhere vanilla can reach. `gain_xp` is the engine's sole gameplay XP writer - combat, farming, fishing, mining, archaeology, ranching, and cooking all call it - so one edit filters every skill's XP. Save load and the debug menu write `skill_xp` directly and never pass through.
+
+## See Also
+
+- [player.xp_delta](../hooks/player.xp_delta.md) - This is the hook this seam dispatches.
+- [player_essence_delta](player_essence_delta.md) - This seam's sibling: the other delta filter that carries its own floor.
+- [statue_hp_death_sweep](statue_hp_death_sweep.md) - The other place the catalog patches an engine gap vanilla cannot reach.

--- a/docs/MMAPI/seams/shroom_puddle_mask.md
+++ b/docs/MMAPI/seams/shroom_puddle_mask.md
@@ -27,5 +27,6 @@ The replace changes one argument: the tarball's mask is set from `self.sprite_in
 
 ## See Also
 
-- [game_step_begin_installs](game_step_begin_installs.md) - This is the catalog's other engine fix, the MMAPI lifecycle root.
+- [game_step_begin_installs](game_step_begin_installs.md) - This is another of the catalog's engine fixes, the MMAPI lifecycle root.
+- [statue_hp_death_sweep](statue_hp_death_sweep.md) - This is another of the catalog's engine fixes, the griffin statue's missing death check.
 - [monster_shroom_should_hide](monster_shroom_should_hide.md) - This is the shroom's other seam. It guards the hide behavior of the monster that lays these puddles.

--- a/docs/MMAPI/seams/statue_hp_death_sweep.md
+++ b/docs/MMAPI/seams/statue_hp_death_sweep.md
@@ -1,0 +1,67 @@
+# Engine Fix: statue_hp_death_sweep
+
+Adds the Living Griffin Statue's missing depleted-hp death check, the branch every other hp-driven monster carries.
+
+`statue_hp_death_sweep` is an **engine fix**, an anchored edit with no hook behind it. Nothing dispatches. The added branch is the whole feature. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/objects/obj_monster_statue.gml` |
+| **Locator** | text anchor: the tail of the statue's damage drain (the drain-side kill check and its closing braces) |
+| **Feeds** | (no hook) |
+| **Marker** | `mmapi_statue_hp_sweep` |
+
+## The Edit
+
+Every hp-driven monster drains its damage receiver behind an `if self.hit_points > 0` gate and pairs it with a depleted-hp death check, in one of two shapes. Group 1 (mite, bat, cat, enchantern, sap, tome) makes it the gate's else branch:
+
+```gml
+if self.hit_points > 0 {
+    // drain the receiver; a drained kill transitions to Dying in here
+} else if csi != MiteState.Dying {
+    self.fsm.change_state(MiteState.Dying);
+}
+```
+
+Group 2 (spirit, shroom, clod, rock_stack) hoists the same check above the drain:
+
+```gml
+if self.hit_points <= 0 {
+    if self.fsm.current_state_id() != SpiritState.Dying {
+        self.fsm.change_state(SpiritState.Dying);
+    }
+}
+```
+
+The statue alone has neither. Its only Dying transition is drain-side, inside the gate, so hp reaching zero outside a drained hit fails the gate every frame from then on. The statue in that state is never dead, never draining another tarball, and undamageable. The replace appends to the statue's tail, transforming it into the Group 1 shape its damage code already follows:
+
+```gml
+if self.hit_points > 0 {
+    var took_any_damage = false;
+
+    while true {
+        var next_dmg = self.receiver.try_take_damage();
+        // ... apply damage, numbers, knockback ...
+    }
+
+    if took_any_damage {
+        // ... tumble state switch, patience ...
+        if self.hit_points <= 0 {
+            self.fsm.change_state(StatueState.Dying);
+        }
+    }
+} else if csi != StatueState.Dying {
+    self.fsm.change_state(StatueState.Dying); // mmapi_statue_hp_sweep
+}
+```
+
+`csi` is the statue's own cached `fsm.current_state_id()`; the guard prevents re-entry after a drain-side kill. The added line carries the `mmapi_statue_hp_sweep` marker as a trailing comment. The Dying state is self-contained (`monster_death_poof` after `config.dying_frames`), so a sweep-entered death is indistinguishable from a hit death.
+
+## See Also
+
+- [monster_death](monster_death.md) - This seam observes the death routine this fix makes reachable for a depleted statue.
+- [monster_step_begin](monster_step_begin.md) - This is the per-frame seam a mod would use to observe (or deplete) monster hp; the fix makes an hp write lethal for the statue the way it already is for every swept monster.
+- [game_step_begin_installs](game_step_begin_installs.md) - This is another of the catalog's engine fixes, the MMAPI lifecycle root.
+- [shroom_puddle_mask](shroom_puddle_mask.md) - This is another of the catalog's engine fixes, also a combat-object correction.


### PR DESCRIPTION
This release extends the MMAPI (Mods of Mistria API) seam catalog with new player-economy and fishing hooks, adds an engine fix for a monster soft-lock, and improves hotkey conflict diagnostics. The catalog now declares **93 hooks, 100 seams, 3 engine fixes, and 1 call rewrite**.

### New Hooks
Six new **filter** hooks let mods intercept player resource and progression changes before they apply (register with `mmapi_filter`):

- **`player.gold_delta`**:  change every gold gain or spend before it applies.
- **`player.essence_delta`**:  change every essence gain or spend before it applies (floored so the total never goes negative).
- **`player.mana_delta`**:  change every mana gain or spend before it applies. A companion seam (`player_mana_item_delta`) reroutes the mana potion's direct `set_mana` call through `modify_mana`, so item restores now fire this filter too.
- **`player.xp_delta`**:  change every skill XP gain before it applies, or turn it into a deduction; the total floors at zero and the level-up celebration is narrowed to genuine gains.
- **`player.renown_delta`**:  change every renown gain before it applies, or turn it into a deduction. Fires once per pending entry at day rollover.
- **`fishing.should_reel`**:  change whether the player reels while waiting for a fish, each frame of the fishing `Wait` state. `ctx` exposes `bite_active`.

### New Engine Patch
- **`statue_hp_death_sweep`**:  adds the Living Griffin Statue's missing depleted-HP death check, the branch every other HP-driven monster already carries. Previously, if the statue's HP reached zero outside a drained hit, it could enter a state where it was never dead, never draining, and undamageable:  a potential soft-lock. This is a hook-less anchored edit; the added branch is the whole fix.

### Other Fixes
- **Hotkey conflict and poll-failure warnings now name the key** (e.g. `F5`, `NUMPAD_3`) instead of printing the raw `vk` ordinal, via a new `mmapi_hotkey_name_from_vk` reverse lookup.
- **Guarded the hotkey name scan's `vk_*` constant reads**:  those constants exist in the live runtime but not the tier-1 VM, so each probe is wrapped so a diagnostics path can never throw; an unresolvable code falls back to the `vk <ordinal>` form.

### Documentation
- **`create_notification`**:  clarified that its argument is a **localization key** (resolved engine-side through `local_get`, so `local.get` filters apply:  pass the key, never pre-localized text), documented the optional repeat-suppression frame argument, and noted `wrap_for_local(...)` for untranslatable prototypes. Updated across API Reference, Quick Start, Recipes, and Mod Anatomy.
- **`game.room_changed`**:  added a warning against caching `ctx.current` for a later decision. It's a lagging derived-event echo (poll lag, no event on load-into-room, `gm_room` asset values rather than name strings); read `room()` live at the point of use and treat the event as an edge trigger only. Cross-referenced `game.room_transition_pre` for request-time semantics.
- Added cross-references from `player.health_delta`, `player.stamina_delta`, and `spells.cost` to the new delta hooks, and updated the Catalog and Seams indexes.
