### PR TITLE
feat(l10n): add full russian and Ukrainian localizations

### DIFF
--- a/ModsOfMistriaInstallerLib/Lang/Resources.Designer.cs
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.Designer.cs
@@ -258,7 +258,7 @@ namespace Garethp.ModsOfMistriaInstallerLib.Lang {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An error occured when reading the version for the mod: (0).
+        ///   Looks up a localized string similar to An error occured when reading the version for the mod: {0}.
         /// </summary>
         public static string CoreErrorReadingVersionForMod {
             get {

--- a/ModsOfMistriaInstallerLib/Lang/Resources.de.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.de.resx
@@ -274,7 +274,7 @@
     <value>Während der Installation wird MOMI versuchen einen Eintrag, in deinem Register deines Computers, zu entfernen. Dafür wirst du gebeten dem Administrator Zugang zum "Registrierungs-Konsolen-Werkzeug" zu gewähren.</value>
   </data>
   <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
-    <value>Ein Fehler trat beim Lesen der Version der Mod auf: (0)</value>
+    <value>Ein Fehler trat beim Lesen der Version der Mod auf: {0}</value>
   </data>
   <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
     <value>Gegenstand wurde keinem Laden zugeordnet.</value>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.fr.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.fr.resx
@@ -274,7 +274,7 @@
     <value>Pendant l'installation, MOMI tentera de supprimer une entrée dans le registre de votre ordinateur. Pour cela, il vous sera demandé de donner les accès administrateur au &quot;Registry Console Tool&quot;.</value>
   </data>
   <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
-    <value>Une erreur s'est produite lors de la lecture de la version du mod&#160;: (0)</value>
+    <value>Une erreur s'est produite lors de la lecture de la version du mod&#160;: {0}</value>
   </data>
   <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
     <value>L'objet n'a pas été assigné à un magasin.</value>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.nl.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.nl.resx
@@ -271,7 +271,7 @@
     <value>Tijdens de installatie probeert MOMI een vermelding uit het Windows-register te verwijderen. Hiervoor wordt u gevraagd beheerdersrechten te verlenen aan het hulpprogramma 'Registry Console Tool'.</value>
   </data>
   <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
-    <value>Er is een fout opgetreden bij het lezen van de versie van de mod: (0)</value>
+    <value>Er is een fout opgetreden bij het lezen van de versie van de mod: {0}</value>
   </data>
   <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
     <value>Item is niet toegewezen aan een winkel.</value>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.pt-br.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.pt-br.resx
@@ -274,7 +274,7 @@
     <value>Durante a instalação, o MOMI vai tentar remover uma entrada do registro do computador. Como parte deste processo, será solicitado que você dê acesso de administrador a &quot;Ferramenta do Console de Registro&quot;.</value>
   </data>
   <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
-    <value>Um erro ocorreu ao ler a versão do mod: (0)</value>
+    <value>Um erro ocorreu ao ler a versão do mod: {0}</value>
   </data>
   <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
     <value>Um item não foi associado a uma loja.</value>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.resx
@@ -277,7 +277,7 @@
     <value>During install, MOMI will attempt to remove an entry from the computers Registry. As part of this, you'll be asked to grant admin access to the "Registry Console Tool".</value>
   </data>
   <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
-    <value>An error occured when reading the version for the mod: (0)</value>
+    <value>An error occured when reading the version for the mod: {0}</value>
   </data>
   <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
     <value>Item has not been assigned to a store.</value>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.ru.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.ru.resx
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CLIRunningBuild" xml:space="preserve">
+    <value>Запуск сборки {0}</value>
+  </data>
+  <data name="CLICompleted" xml:space="preserve">
+    <value>Завершено. Нажмите любую клавишу для выхода.</value>
+  </data>
+  <data name="CLIUninstallComplete" xml:space="preserve">
+    <value>Все моды удалены. Нажмите любую клавишу для выхода.</value>
+  </data>
+  <data name="CLIWarning32Bit" xml:space="preserve">
+    <value>Вы используете 64-разрядную операционную систему, но случайно скачали 32-разрядную версию MOMI. Пожалуйста, скачайте версию MOMI без суффикса «-x86».</value>
+  </data>
+  <data name="CLICompileCheckUsage" xml:space="preserve">
+    <value>Параметр --compile-check должен иметь значение "on", "off" или "require".</value>
+  </data>
+  <data name="CLILintUsage" xml:space="preserve">
+    <value>Параметру --lint требуется папка мода: --lint &lt;папка мода&gt; [исходный zip-архив]</value>
+  </data>
+  <data name="CoreLookingForMistriaAt" xml:space="preserve">
+    <value>Поиск игры Fields of Mistria в {0}</value>
+  </data>
+  <data name="CoreMistriaNotFoundFallback" xml:space="preserve">
+    <value>Игра Fields of Mistria не найдена, возврат к текущей папке</value>
+  </data>
+  <data name="CoreCouldNotFindModManifest" xml:space="preserve">
+    <value>Не удалось найти файл манифеста.</value>
+  </data>
+  <data name="CoreManifestFileNamedIncorrectly" xml:space="preserve">
+    <value>Файл манифеста должен называться manifest.json.</value>
+  </data>
+  <data name="CoreManifestHasNoAuthor" xml:space="preserve">
+    <value>В манифесте должен быть указан автор (author).</value>
+  </data>
+  <data name="CoreManifestHasNoName" xml:space="preserve">
+    <value>В манифесте должно быть указано название (name).</value>
+  </data>
+  <data name="CoreManifestHasNoVersion" xml:space="preserve">
+    <value>В манифесте должна быть указана версия (version).</value>
+  </data>
+  <data name="CoreModRequiresNewerInstaller" xml:space="preserve">
+    <value>Для этого мода требуется более новая версия установщика.</value>
+  </data>
+  <data name="CoreMistriaLocationDoesNotExist" xml:space="preserve">
+    <value>Путь к игре Fields of Mistria не существует.</value>
+  </data>
+  <data name="CoreModDirectoryDoesNotExist" xml:space="preserve">
+    <value>Путь к папке мода не существует.</value>
+  </data>
+  <data name="CoreGeneratingInformationForMod" xml:space="preserve">
+    <value>Генерация информации для {0}</value>
+  </data>
+  <data name="CoreInstallCompleted" xml:space="preserve">
+    <value>Завершено</value>
+  </data>
+  <data name="CoreMistriaNotFound" xml:space="preserve">
+    <value>Не удалось найти расположение Fields of Mistria.</value>
+  </data>
+  <data name="CoreCouldNotGuessModsAt" xml:space="preserve">
+    <value>Не удалось найти папку модов (mods) в {0}.</value>
+  </data>
+  <data name="CoreGuessedMistriaAt" xml:space="preserve">
+    <value>Предполагаемое расположение: {0}</value>
+  </data>
+  <data name="CoreSkippingModBecauseInstallerOld" xml:space="preserve">
+    <value>Пропуск {0}, так как моду требуется более новая версия установщика.</value>
+  </data>
+  <data name="CoreSkippingModBecauseErrors" xml:space="preserve">
+    <value>Пропуск {0} из-за следующих ошибок:</value>
+  </data>
+  <data name="CoreModHasWarnings" xml:space="preserve">
+    <value>В {0} обнаружены следующие предупреждения, но мод всё равно будет установлен:</value>
+  </data>
+  <data name="CoreInstalledInReporter" xml:space="preserve">
+    <value>Мод {0} установлен за {1}</value>
+  </data>
+  <data name="CoreModsInstalledInTime" xml:space="preserve">
+    <value>Моды установлены за {0}</value>
+  </data>
+  <data name="CoreItemDoesNotHaveValue" xml:space="preserve">
+    <value>{0} не имеет значения</value>
+  </data>
+  <data name="CoreSpriteFileDoesNotExist" xml:space="preserve">
+    <value>{0} ссылается на спрайт в {1}, но этот файл не существует</value>
+  </data>
+  <data name="CoreSpriteFolderDoesNotExist" xml:space="preserve">
+    <value>{0} ссылается на папку со спрайтами в {1}, но эта папка не существует</value>
+  </data>
+  <data name="CoreSpriteFolderIsEmpty" xml:space="preserve">
+    <value>{0} ссылается на папку со спрайтами в {1}, но эта директория пуста</value>
+  </data>
+  <data name="CoreCouldNotParseJSON" xml:space="preserve">
+    <value>Не удалось обработать файл. Ошибка: {0}</value>
+  </data>
+  <data name="CoreNoDataInJSON" xml:space="preserve">
+    <value>В файле не найдено данных</value>
+  </data>
+  <data name="CoreOutfitFileHasNoOutfits" xml:space="preserve">
+    <value>В файле нарядов (outfits) нет данных о нарядах.</value>
+  </data>
+  <data name="CoreSpriteFileHasNoSprites" xml:space="preserve">
+    <value>В файле спрайтов нет данных о спрайтах.</value>
+  </data>
+  <data name="CoreStoreFileHasNoData" xml:space="preserve">
+    <value>В файле магазина (store) нет категорий или предметов.</value>
+  </data>
+  <data name="CoreTilesetsFileEmpty" xml:space="preserve">
+    <value>В файле тайлсетов нет данных о тайлсетах.</value>
+  </data>
+  <data name="CoreReadingSprites" xml:space="preserve">
+    <value>Чтение текстур/спрайтов</value>
+  </data>
+  <data name="CoreImportingSprites" xml:space="preserve">
+    <value>Импорт текстур/спрайтов</value>
+  </data>
+  <data name="CoreWritingSprites" xml:space="preserve">
+    <value>Запись текстур/спрайтов</value>
+  </data>
+  <data name="CoreErrorOutfitNoName" xml:space="preserve">
+    <value>У наряда не указано название.</value>
+  </data>
+  <data name="CoreErrorOutfitNoDescription" xml:space="preserve">
+    <value>У наряда не указано описание.</value>
+  </data>
+  <data name="CoreErrorOutfitNoUiSlot" xml:space="preserve">
+    <value>Для наряда {0} не задан параметр ui_slot.</value>
+  </data>
+  <data name="CoreErrorOutfitNoSubCategory" xml:space="preserve">
+    <value>Для наряда {0} не задан параметр ui_sub_category.</value>
+  </data>
+  <data name="CoreErrorOutfitNoAnimation" xml:space="preserve">
+    <value>Для наряда {0} отсутствуют файлы анимации.</value>
+  </data>
+  <data name="CoreErrorStoreCategoryNoName" xml:space="preserve">
+    <value>У категории не указано имя иконки (icon name).</value>
+  </data>
+  <data name="CoreErrorShadowHasNoLocation" xml:space="preserve">
+    <value>Для тени {0} не задано расположение (Location)</value>
+  </data>
+  <data name="CoreWarningShadowFileNoShadows" xml:space="preserve">
+    <value>В файле теней нет данных о тенях.</value>
+  </data>
+  <data name="CoreErrorShadowHasNoSprite" xml:space="preserve">
+    <value>У тени {0} отсутствует параметр regular_sprite_name</value>
+  </data>
+  <data name="CoreErrorModRequiresWindows" xml:space="preserve">
+    <value>Этот мод работает только на Windows и не будет установлен.</value>
+  </data>
+  <data name="CoreErrorOutfitUiSlotWrong" xml:space="preserve">
+    <value>У наряда {0} неверный параметр ui_slot. Должен быть один из: {1}.</value>
+  </data>
+  <data name="CoreErrorOutfitUiSubCategoryWrong" xml:space="preserve">
+    <value>У наряда {0} неверный параметр ui_sub_category. Должен быть один из: {1}.</value>
+  </data>
+  <data name="CorePreinstallWillInstallAurie" xml:space="preserve">
+    <value>Во время установки MOMI попытается добавить запись в реестр вашего компьютера. Для этого вас попросят предоставить права администратора «Редактору реестра» (Registry Editor) и разрешить внесение изменений в реестр.</value>
+  </data>
+  <data name="CorePreinstallWillRemoveAurie" xml:space="preserve">
+    <value>Во время установки/удаления MOMI попытается удалить запись из реестра компьютера. В связи с этим вас попросят предоставить права администратора «Консольной утилите реестра» (Registry Console Tool).</value>
+  </data>
+  <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
+    <value>Произошла ошибка при чтении версии мода: {0}</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
+    <value>Предмет не был привязан к магазине (store).</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoCategory" xml:space="preserve">
+    <value>Предмет для магазина {0} не имеет категории.</value>
+  </data>
+  <data name="CoreErrorStoreItemHasInvalidSeason" xml:space="preserve">
+    <value>Невозможно добавить предмет в магазин {0} (категория {1}), так как у него указан недопустимый сезон {2}.</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoItem" xml:space="preserve">
+    <value>Для записи в магазине {0} (категория {1}) не указан сам предмет.</value>
+  </data>
+  <data name="CoreErrorStoreCategoryHasNoStore" xml:space="preserve">
+    <value>У категории не указан магазин.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoName" xml:space="preserve">
+    <value>У нового объекта нет названия.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoCategory" xml:space="preserve">
+    <value>У объекта {0} не указана категория.</value>
+  </data>
+  <data name="CoreErrorNewObjectInvalidCategory" xml:space="preserve">
+    <value>У объекта {0} указана неверная категория {1}.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoData" xml:space="preserve">
+    <value>У объекта {0} отсутствуют данные.</value>
+  </data>
+  <data name="CoreWarningObjectFileHasNoObjects" xml:space="preserve">
+    <value>В файле новых объектов нет объектов.</value>
+  </data>
+  <data name="CoreWarningItemFileHasNoItems" xml:space="preserve">
+    <value>В файле новых предметов нет предметов.</value>
+  </data>
+  <data name="CoreErrorNewObjectHasNoOverwritesOtherMod" xml:space="preserve">
+    <value>Для объекта {0} не указано, перезаписывает ли он другой мод (overwrites_other_mod).</value>
+  </data>
+  <data name="CoreErrorNewItemHasNoOverwritesOtherMod" xml:space="preserve">
+    <value>Для предмета {0} не указано, перезаписывает ли он другой мод (overwrites_other_mod).</value>
+  </data>
+  <data name="GUIApplicationTitle" xml:space="preserve">
+    <value>Mods Of Mistria Installer</value>
+  </data>
+  <data name="GUIGreetingText" xml:space="preserve">
+    <value>Добро пожаловать в установщик Mods of Mistria (MOMI)!</value>
+  </data>
+  <data name="GUIInstallButtonText" xml:space="preserve">
+    <value>Установить</value>
+  </data>
+  <data name="GUIFieldsOfMistriaDetectedLocation" xml:space="preserve">
+    <value>Игра Fields of Mistria обнаружена в: </value>
+  </data>
+  <data name="GUIModsWillBeInstalled" xml:space="preserve">
+    <value>Отметьте галочками моды, которые вы хотите установить:</value>
+  </data>
+  <data name="GUIModByAuthorWithVersion" xml:space="preserve">
+    <value>{0} от {1} — Версия {2}</value>
+  </data>
+  <data name="GUICouldNotFindMistria" xml:space="preserve">
+    <value>Не удалось найти расположение Fields of Mistria. Попробуйте поместить эту программу в ту же папку, где находится игра.</value>
+  </data>
+  <data name="GUICouldNotFindMods" xml:space="preserve">
+    <value>Не удалось найти папку с модами. Попробуйте создать папку с именем «mods» в корневой папке Fields of Mistria.</value>
+  </data>
+  <data name="GUINoModsToInstall" xml:space="preserve">
+    <value>Не найдено модов для установки</value>
+  </data>
+  <data name="GUIModsRequireNewerVersion" xml:space="preserve">
+    <value>Для некоторых модов требуется более новая версия установщика. Пожалуйста, обновите программу.</value>
+  </data>
+  <data name="GUIInstallInProgress" xml:space="preserve">
+    <value>Установка модов...</value>
+  </data>
+  <data name="GUIModHasWarnings" xml:space="preserve">
+    <value>В этом моде есть предупреждения, которые можно проигнорировать</value>
+  </data>
+  <data name="GUIModHasErrors" xml:space="preserve">
+    <value>В этом моде есть критические ошибки, он не будет установлен</value>
+  </data>
+  <data name="GUIModInstalled" xml:space="preserve">
+    <value>Успешно установлено.</value>
+  </data>
+  <data name="GUIModSkipped" xml:space="preserve">
+    <value>Этот мод был пропущен во время установки</value>
+  </data>
+  <data name="GUIUpdateNagTitle" xml:space="preserve">
+    <value>Доступна новая версия</value>
+  </data>
+  <data name="GUIUpdateNagMessage" xml:space="preserve">
+    <value>Доступна новая версия Mods Of Mistria Installer, пожалуйста, обновите программу.</value>
+  </data>
+  <data name="GUIUninstallButtonText" xml:space="preserve">
+    <value>Удалить все</value>
+  </data>
+  <data name="GUIPreinstallInformationTitle" xml:space="preserve">
+    <value>Информация об установке</value>
+  </data>
+  <data name="GUIUninstallInformationTitle" xml:space="preserve">
+    <value>Информация об удалении</value>
+  </data>
+  <data name="GUIWarning32Bit" xml:space="preserve">
+    <value>Вы используете 64-разрядную операционную систему, но случайно скачали 32-разрядную версию MOMI. Пожалуйста, скачайте версию MOMI без суффикса «-x86».</value>
+  </data>
+  <data name="GUIWarning32BitTitle" xml:space="preserve">
+    <value>Обнаружена 32-разрядная версия</value>
+  </data>
+  <data name="GUISetupMistriaLocation" xml:space="preserve">
+    <value>Расположение Fields Of Mistria:</value>
+  </data>
+  <data name="GUISetupModsLocation" xml:space="preserve">
+    <value>Папка с модами:</value>
+  </data>
+  <data name="GUICanCreateModsFolder" xml:space="preserve">
+    <value>Папка для модов не обнаружена, но она может быть создана автоматически.</value>
+  </data>
+  <data name="GUISaveLogFile" xml:space="preserve">
+    <value>Сохранить файл журнала (лог)</value>
+  </data>
+  <data name="GUIPickLogFile" xml:space="preserve">
+    <value>Выберите место для сохранения файла журнала</value>
+  </data>
+  <data name="GUIEnableAllMods" xml:space="preserve">
+    <value>Включить все моды</value>
+  </data>
+  <data name="GUIDisableAllMods" xml:space="preserve">
+    <value>Отключить все моды</value>
+  </data>
+  <data name="GUIReloadModlist" xml:space="preserve">
+    <value>Обновить список модов</value>
+  </data>
+  <data name="CoreErrorStoreItemAnimalHasNoCosmetic" xml:space="preserve">
+    <value>Для животного {0} в магазине {1} не задан косметический параметр (cosmetic).</value>
+  </data>
+  <data name="GUIGreetingText_April" xml:space="preserve">
+    <value>А вы знали, что вдумчивый удар киркой — отличный способ установить любые скачанные вами моды?</value>
+  </data>
+  <data name="GUIInstallButtonText_April" xml:space="preserve">
+    <value>Вдумчиво ударить</value>
+  </data>
+  <data name="GUIInstallInProgress_April" xml:space="preserve">
+    <value>Вдумчивый удар...</value>
+  </data>
+  <data name="GUINoModsToInstall_April" xml:space="preserve">
+    <value>Не найдено модов для удара</value>
+  </data>
+  <data name="GUIModsWillBeInstalled_April" xml:space="preserve">
+    <value>Отметьте галочками моды, по которым вы хотите ударить:</value>
+  </data>
+  <data name="CoreErrorOutfitPriceOverrideNegative" xml:space="preserve">
+    <value>Переопределение цены для наряда {0} должно быть положительным числом.</value>
+  </data>
+  <data name="CoreRunningInstaller" xml:space="preserve">
+    <value>Запуск {0}</value>
+  </data>
+  <data name="CoreErrorSpriteHasNoLocation" xml:space="preserve">
+    <value>У спрайта {0} не задано расположение (Location).</value>
+  </data>
+  <data name="CoreManifestHasNoMinimunInstallerVersion" xml:space="preserve">
+    <value>Из-за обновления движка игры этот мод не может быть установлен в его текущей версии.</value>
+  </data>
+  <data name="CoreModRequiresIncorrectVersion" xml:space="preserve">
+    <value>Моду требуется некорректная минимальная версия MOMI.</value>
+  </data>
+  <data name="CoreStoreRebuildFailed" xml:space="preserve">
+    <value>Не удалось пересобрать {0}. Игра Fields of Mistria запущена? Закройте её и попробуйте снова; предыдущая установка не затронута.</value>
+  </data>
+  <data name="CoreStoreFlushFailed" xml:space="preserve">
+    <value>Не удалось завершить запись в {0}. Убедитесь, что на диске есть свободное место, а файл не занят другой программой (например, антивирусом), затем запустите установщик снова.</value>
+  </data>
+  <data name="CoreStoreRestoreFailed" xml:space="preserve">
+    <value>Не удалось восстановить {0}. Игра Fields of Mistria запущена? Закройте её и попробуйте снова.</value>
+  </data>
+  <data name="CoreStoreBackupMissing" xml:space="preserve">
+    <value>{0} содержит данные о предыдущей установке, но резервная копия {1} отсутствует. Пожалуйста, проверьте целостность файлов игры в Steam и попробуйте снова.</value>
+  </data>
+  <data name="CoreStoreUnreadableNoBackup" xml:space="preserve">
+    <value>Архив {0} не читается, а резервная копия {1} отсутствует. Пожалуйста, проверьте целостность файлов игры в Steam и попробуйте снова.</value>
+  </data>
+  <data name="CoreStoreNoArchives" xml:space="preserve">
+    <value>Не удалось найти {0} или {1}. Запустите игру хотя бы один раз или проверьте целостность файлов игры через Steam.</value>
+  </data>
+  <data name="CoreStoreNothingToUninstall" xml:space="preserve">
+    <value>Хранилище ресурсов не найдено, восстанавливать нечего.</value>
+  </data>
+  <data name="CoreInstallSummary" xml:space="preserve">
+    <value>Установлено модов: {0}</value>
+  </data>
+  <data name="CoreInstallSummaryWithSkipped" xml:space="preserve">
+    <value>Установлено модов: {0}, пропущено: {1}</value>
+  </data>
+  <data name="CoreGameGmlChanged" xml:space="preserve">
+    <value>GML игры изменён. Установка невозможна.</value>
+  </data>
+  <data name="CoreModRequiresMissingHooks" xml:space="preserve">
+    <value>Для мода требуются хуки (hooks), которых нет в данной версии MOMI: {0}. Обновите MOMI или используйте более старую версию мода.</value>
+  </data>
+  <data name="CoreManifestRequiresHooksInvalid" xml:space="preserve">
+    <value>Параметр requires_hooks в манифесте должен быть массивом строк с именами хуков.</value>
+  </data>
+  <data name="CoreSkippedModReason" xml:space="preserve">
+    <value>Пропущено {0}: {1}</value>
+  </data>
+  <data name="CoreVerifyNoBackup" xml:space="preserve">
+    <value>Чистая резервная копия не найдена в {0}. Запустите установщик один раз для её создания или выполните проверку швов (seam check) непосредственно с zip-архивом сборки.</value>
+  </data>
+  <data name="GUIUninstallCompleteText" xml:space="preserve">
+    <value>Удаление завершено</value>
+  </data>
+  <data name="GUIUninstallingText" xml:space="preserve">
+    <value>Удаление...</value>
+  </data>
+  <data name="GUIInstallFatalError" xml:space="preserve">
+    <value>Произошла критическая ошибка во время установки модов:</value>
+  </data>
+  <data name="GUIUninstallFatalError" xml:space="preserve">
+    <value>Произошла критическая ошибка во время удаления модов:</value>
+  </data>
+</root>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.uk.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.uk.resx
@@ -1,0 +1,439 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CLIRunningBuild" xml:space="preserve">
+    <value>Запуск збірки {0}</value>
+  </data>
+  <data name="CLICompleted" xml:space="preserve">
+    <value>Завершено. Натисніть будь-яку клавішу для виходу.</value>
+  </data>
+  <data name="CLIUninstallComplete" xml:space="preserve">
+    <value>Усі моди видалено. Натисніть будь-яку клавішу для виходу.</value>
+  </data>
+  <data name="CLIWarning32Bit" xml:space="preserve">
+    <value>Ви використовуєте 64-розрядну операційну систему, але випадково завантажили 32-розрядну версію MOMI. Будь ласка, завантажте версію MOMI без суфікса «-x86».</value>
+  </data>
+  <data name="CLICompileCheckUsage" xml:space="preserve">
+    <value>Параметр --compile-check має мати значення «on», «off» або «require».</value>
+  </data>
+  <data name="CLILintUsage" xml:space="preserve">
+    <value>Параметр --lint потребує вказування папки мода: --lint &lt;папка мода&gt; [оригінальний zip-архів]</value>
+  </data>
+  <data name="CoreLookingForMistriaAt" xml:space="preserve">
+    <value>Пошук гри Fields of Mistria в {0}</value>
+  </data>
+  <data name="CoreMistriaNotFoundFallback" xml:space="preserve">
+    <value>Гру Fields of Mistria не знайдено, повернення до поточної папки</value>
+  </data>
+  <data name="CoreCouldNotFindModManifest" xml:space="preserve">
+    <value>Не вдалося знайти файл маніфесту.</value>
+  </data>
+  <data name="CoreManifestFileNamedIncorrectly" xml:space="preserve">
+    <value>Файл маніфесту має називатися manifest.json.</value>
+  </data>
+  <data name="CoreManifestHasNoAuthor" xml:space="preserve">
+    <value>У маніфесті має бути вказаний автор (author).</value>
+  </data>
+  <data name="CoreManifestHasNoName" xml:space="preserve">
+    <value>У маніфесті має бути вказана назва (name).</value>
+  </data>
+  <data name="CoreManifestHasNoVersion" xml:space="preserve">
+    <value>У маніфесті має бути вказана версія (version).</value>
+  </data>
+  <data name="CoreModRequiresNewerInstaller" xml:space="preserve">
+    <value>Для цього мода потрібна новіша версія інсталятора.</value>
+  </data>
+  <data name="CoreMistriaLocationDoesNotExist" xml:space="preserve">
+    <value>Шлях до гри Fields of Mistria не існує.</value>
+  </data>
+  <data name="CoreModDirectoryDoesNotExist" xml:space="preserve">
+    <value>Шлях до папки мода не існує.</value>
+  </data>
+  <data name="CoreGeneratingInformationForMod" xml:space="preserve">
+    <value>Генерування інформації для {0}</value>
+  </data>
+  <data name="CoreInstallCompleted" xml:space="preserve">
+    <value>Завершено</value>
+  </data>
+  <data name="CoreMistriaNotFound" xml:space="preserve">
+    <value>Не вдалося знайти розташування Fields of Mistria.</value>
+  </data>
+  <data name="CoreCouldNotGuessModsAt" xml:space="preserve">
+    <value>Не вдалося знайти папку з модами (mods) в {0}.</value>
+  </data>
+  <data name="CoreGuessedMistriaAt" xml:space="preserve">
+    <value>Ймовірне розташування: {0}</value>
+  </data>
+  <data name="CoreSkippingModBecauseInstallerOld" xml:space="preserve">
+    <value>Пропуск {0}, оскільки для нього потрібна новіша версія інсталятора.</value>
+  </data>
+  <data name="CoreSkippingModBecauseErrors" xml:space="preserve">
+    <value>Пропуск {0} через такі помилки:</value>
+  </data>
+  <data name="CoreModHasWarnings" xml:space="preserve">
+    <value>У {0} є такі попередження, але мод усе одно буде встановлено:</value>
+  </data>
+  <data name="CoreInstalledInReporter" xml:space="preserve">
+    <value>Мод {0} встановлено за {1}</value>
+  </data>
+  <data name="CoreModsInstalledInTime" xml:space="preserve">
+    <value>Моди встановлено за {0}</value>
+  </data>
+  <data name="CoreItemDoesNotHaveValue" xml:space="preserve">
+    <value>{0} не має значення</value>
+  </data>
+  <data name="CoreSpriteFileDoesNotExist" xml:space="preserve">
+    <value>{0} вказує на спрайт у {1}, але цей файл не існує</value>
+  </data>
+  <data name="CoreSpriteFolderDoesNotExist" xml:space="preserve">
+    <value>{0} вказує на папку зі спрайтами в {1}, але ця директорія не існує</value>
+  </data>
+  <data name="CoreSpriteFolderIsEmpty" xml:space="preserve">
+    <value>{0} вказує на папку зі спрайтами в {1}, але ця директорія порожня</value>
+  </data>
+  <data name="CoreCouldNotParseJSON" xml:space="preserve">
+    <value>Не вдалося обробити файл. Помилка: {0}</value>
+  </data>
+  <data name="CoreNoDataInJSON" xml:space="preserve">
+    <value>У файлі не знайдено даних</value>
+  </data>
+  <data name="CoreOutfitFileHasNoOutfits" xml:space="preserve">
+    <value>У файлі вбрання (outfits) немає даних про вбрання.</value>
+  </data>
+  <data name="CoreSpriteFileHasNoSprites" xml:space="preserve">
+    <value>У файлі спрайтів немає даних про спрайти.</value>
+  </data>
+  <data name="CoreStoreFileHasNoData" xml:space="preserve">
+    <value>У файлі магазину (store) немає категорій або предметів.</value>
+  </data>
+  <data name="CoreTilesetsFileEmpty" xml:space="preserve">
+    <value>У файлі тайлсетів немає даних про тайлсети.</value>
+  </data>
+  <data name="CoreReadingSprites" xml:space="preserve">
+    <value>Читання текстур/спрайтів</value>
+  </data>
+  <data name="CoreImportingSprites" xml:space="preserve">
+    <value>Імпортування текстур/спрайтів</value>
+  </data>
+  <data name="CoreWritingSprites" xml:space="preserve">
+    <value>Запис текстур/спрайтів</value>
+  </data>
+  <data name="CoreErrorOutfitNoName" xml:space="preserve">
+    <value>У вбрання немає назви.</value>
+  </data>
+  <data name="CoreErrorOutfitNoDescription" xml:space="preserve">
+    <value>У вбрання немає опису.</value>
+  </data>
+  <data name="CoreErrorOutfitNoUiSlot" xml:space="preserve">
+    <value>Для вбрання {0} не визначено параметр ui_slot.</value>
+  </data>
+  <data name="CoreErrorOutfitNoSubCategory" xml:space="preserve">
+    <value>Для вбрання {0} не визначено параметр ui_sub_category.</value>
+  </data>
+  <data name="CoreErrorOutfitNoAnimation" xml:space="preserve">
+    <value>Для вбрання {0} відсутні файли анімації.</value>
+  </data>
+  <data name="CoreErrorStoreCategoryNoName" xml:space="preserve">
+    <value>У категорії не вказано назву іконки (icon name).</value>
+  </data>
+  <data name="CoreErrorShadowHasNoLocation" xml:space="preserve">
+    <value>Для тіні {0} не встановлено розташування (Location)</value>
+  </data>
+  <data name="CoreWarningShadowFileNoShadows" xml:space="preserve">
+    <value>У файлі тіней немає даних про тіні.</value>
+  </data>
+  <data name="CoreErrorShadowHasNoSprite" xml:space="preserve">
+    <value>У тіні {0} відсутній параметр regular_sprite_name</value>
+  </data>
+  <data name="CoreErrorModRequiresWindows" xml:space="preserve">
+    <value>Цей мод працює лише на ОС Windows і не буде встановлений.</value>
+  </data>
+  <data name="CoreErrorOutfitUiSlotWrong" xml:space="preserve">
+    <value>У вбрання {0} неправильний параметр ui_slot. Має бути один із: {1}.</value>
+  </data>
+  <data name="CoreErrorOutfitUiSubCategoryWrong" xml:space="preserve">
+    <value>У вбрання {0} неправильний параметр ui_sub_category. Має бути один із: {1}.</value>
+  </data>
+  <data name="CorePreinstallWillInstallAurie" xml:space="preserve">
+    <value>Під час встановлення MOMI спробує додати запис до реєстру вашого комп'ютера. Для цього вас попросять надати права адміністратора «Редактору реєстру» (Registry Editor) і дозволити внесення змін до реєстру.</value>
+  </data>
+  <data name="CorePreinstallWillRemoveAurie" xml:space="preserve">
+    <value>Під час встановлення/видалення MOMI спробує видалити запис із реєстру комп'ютера. У зв'язку з цим вас попросять надати права адміністратора «Консольній утиліті реєстру» (Registry Console Tool).</value>
+  </data>
+  <data name="CoreErrorReadingVersionForMod" xml:space="preserve">
+    <value>Сталася помилка під час читання версії мода: {0}</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoStore" xml:space="preserve">
+    <value>Предмет не було призначено магазину (store).</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoCategory" xml:space="preserve">
+    <value>Предмет для магазину {0} не має категорії.</value>
+  </data>
+  <data name="CoreErrorStoreItemHasInvalidSeason" xml:space="preserve">
+    <value>Неможливо додати предмет до магазину {0} (категорія {1}), оскільки він має недопустимий сезон {2}.</value>
+  </data>
+  <data name="CoreErrorStoreItemHasNoItem" xml:space="preserve">
+    <value>Для запису в магазині {0} (категорія {1}) не вказано сам предмет.</value>
+  </data>
+  <data name="CoreErrorStoreCategoryHasNoStore" xml:space="preserve">
+    <value>У категорії не вказано магазин.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoName" xml:space="preserve">
+    <value>Новий об'єкт не має назви.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoCategory" xml:space="preserve">
+    <value>Об'єкт {0} не має категорії.</value>
+  </data>
+  <data name="CoreErrorNewObjectInvalidCategory" xml:space="preserve">
+    <value>Об'єкт {0} має неправильну категорію {1}.</value>
+  </data>
+  <data name="CoreErrorNewObjectNoData" xml:space="preserve">
+    <value>Об'єкт {0} не містить даних.</value>
+  </data>
+  <data name="CoreWarningObjectFileHasNoObjects" xml:space="preserve">
+    <value>У файлі нових об'єктів немає об'єктів.</value>
+  </data>
+  <data name="CoreWarningItemFileHasNoItems" xml:space="preserve">
+    <value>У файлі нових предметів немає предметів.</value>
+  </data>
+  <data name="CoreErrorNewObjectHasNoOverwritesOtherMod" xml:space="preserve">
+    <value>Для об'єкта {0} не вказано, чи перезаписує він інший мод (overwrites_other_mod).</value>
+  </data>
+  <data name="CoreErrorNewItemHasNoOverwritesOtherMod" xml:space="preserve">
+    <value>Для предмета {0} не вказано, чи перезаписує він інший мод (overwrites_other_mod).</value>
+  </data>
+  <data name="GUIApplicationTitle" xml:space="preserve">
+    <value>Mods Of Mistria Installer</value>
+  </data>
+  <data name="GUIGreetingText" xml:space="preserve">
+    <value>Ласкаво просимо до інсталятора Mods of Mistria (MOMI)!</value>
+  </data>
+  <data name="GUIInstallButtonText" xml:space="preserve">
+    <value>Встановити</value>
+  </data>
+  <data name="GUIFieldsOfMistriaDetectedLocation" xml:space="preserve">
+    <value>Гру Fields of Mistria знайдено за адресою: </value>
+  </data>
+  <data name="GUIModsWillBeInstalled" xml:space="preserve">
+    <value>Позначте галочками всі моди, які ви хочете встановити:</value>
+  </data>
+  <data name="GUIModByAuthorWithVersion" xml:space="preserve">
+    <value>{0} від {1} — Версія {2}</value>
+  </data>
+  <data name="GUICouldNotFindMistria" xml:space="preserve">
+    <value>Не вдалося знайти розташування Fields of Mistria. Спробуйте помістити цю програму в ту ж папку, де знаходиться гра.</value>
+  </data>
+  <data name="GUICouldNotFindMods" xml:space="preserve">
+    <value>Не вдалося знайти папку з модами. Спробуйте створити папку з назвою «mods» у кореневій папці Fields of Mistria.</value>
+  </data>
+  <data name="GUINoModsToInstall" xml:space="preserve">
+    <value>Не знайдено модів для встановлення</value>
+  </data>
+  <data name="GUIModsRequireNewerVersion" xml:space="preserve">
+    <value>Для деяких модів потрібна новіша версія інсталятора. Будь ласка, оновіть програму.</value>
+  </data>
+  <data name="GUIInstallInProgress" xml:space="preserve">
+    <value>Встановлення модів...</value>
+  </data>
+  <data name="GUIModHasWarnings" xml:space="preserve">
+    <value>У цьому моді є попередження, які можна проігнорувати</value>
+  </data>
+  <data name="GUIModHasErrors" xml:space="preserve">
+    <value>У цьому моді є критичні помилки, він не буде встановлений</value>
+  </data>
+  <data name="GUIModInstalled" xml:space="preserve">
+    <value>Успішно встановлено.</value>
+  </data>
+  <data name="GUIModSkipped" xml:space="preserve">
+    <value>Цей мод було пропущено під час встановлення</value>
+  </data>
+  <data name="GUIUpdateNagTitle" xml:space="preserve">
+    <value>Доступна нова версія</value>
+  </data>
+  <data name="GUIUpdateNagMessage" xml:space="preserve">
+    <value>Доступна нова версія інсталятора Mods Of Mistria, будь ласка, оновіть програму.</value>
+  </data>
+  <data name="GUIUninstallButtonText" xml:space="preserve">
+    <value>Видалити все</value>
+  </data>
+  <data name="GUIPreinstallInformationTitle" xml:space="preserve">
+    <value>Інформація про встановлення</value>
+  </data>
+  <data name="GUIUninstallInformationTitle" xml:space="preserve">
+    <value>Інформація про видалення</value>
+  </data>
+  <data name="GUIWarning32Bit" xml:space="preserve">
+    <value>Ви використовуєте 64-розрядну операційну систему, але випадково завантажили 32-розрядну версію MOMI. Будь ласка, завантажте версію MOMI без суфікса «-x86».</value>
+  </data>
+  <data name="GUIWarning32BitTitle" xml:space="preserve">
+    <value>Виявлено 32-розрядну версію</value>
+  </data>
+  <data name="GUISetupMistriaLocation" xml:space="preserve">
+    <value>Розташування Fields Of Mistria:</value>
+  </data>
+  <data name="GUISetupModsLocation" xml:space="preserve">
+    <value>Папка з модами:</value>
+  </data>
+  <data name="GUICanCreateModsFolder" xml:space="preserve">
+    <value>Папку для модів не виявлено, але її можна створити автоматично.</value>
+  </data>
+  <data name="GUISaveLogFile" xml:space="preserve">
+    <value>Зберегти файл журналу (лог)</value>
+  </data>
+  <data name="GUIPickLogFile" xml:space="preserve">
+    <value>Виберіть місце для збереження файлу журналу</value>
+  </data>
+  <data name="GUIEnableAllMods" xml:space="preserve">
+    <value>Увімкнути всі моди</value>
+  </data>
+  <data name="GUIDisableAllMods" xml:space="preserve">
+    <value>Вимкнути всі моди</value>
+  </data>
+  <data name="GUIReloadModlist" xml:space="preserve">
+    <value>Оновити список модів</value>
+  </data>
+  <data name="CoreErrorStoreItemAnimalHasNoCosmetic" xml:space="preserve">
+    <value>Для тварини {0} в магазині {1} не визначено косметичний параметр (cosmetic).</value>
+  </data>
+  <data name="GUIGreetingText_April" xml:space="preserve">
+    <value>А ви знали, що вдумливий удар кайлом — це чудовий спосіб встановити будь-які завантажені вами моди?</value>
+  </data>
+  <data name="GUIInstallButtonText_April" xml:space="preserve">
+    <value>Вдумливо вдарити</value>
+  </data>
+  <data name="GUIInstallInProgress_April" xml:space="preserve">
+    <value>Вдумливий удар...</value>
+  </data>
+  <data name="GUINoModsToInstall_April" xml:space="preserve">
+    <value>Не знайдено модів для удару</value>
+  </data>
+  <data name="GUIModsWillBeInstalled_April" xml:space="preserve">
+    <value>Позначте галочками всі моди, по яких ви хочете вдарити:</value>
+  </data>
+  <data name="CoreErrorOutfitPriceOverrideNegative" xml:space="preserve">
+    <value>Перевизначення ціни для вбрання {0} має бути додатним числом.</value>
+  </data>
+  <data name="CoreRunningInstaller" xml:space="preserve">
+    <value>Запуск {0}</value>
+  </data>
+  <data name="CoreErrorSpriteHasNoLocation" xml:space="preserve">
+    <value>Для спрайта {0} не встановлено розташування (Location).</value>
+  </data>
+  <data name="CoreManifestHasNoMinimunInstallerVersion" xml:space="preserve">
+    <value>Через оновлення рушія гри цей мод неможливо встановити в його поточній версії.</value>
+  </data>
+  <data name="CoreModRequiresIncorrectVersion" xml:space="preserve">
+    <value>Для мода потрібна некоректна мінімальна версія MOMI.</value>
+  </data>
+  <data name="CoreStoreRebuildFailed" xml:space="preserve">
+    <value>Не вдалося перезібрати {0}. Гра Fields of Mistria запущена? Закрийте її та спробуйте знову; попереднє встановлення не порушено.</value>
+  </data>
+  <data name="CoreStoreFlushFailed" xml:space="preserve">
+    <value>Не вдалося завершити запис у {0}. Перевірте, чи є на диску вільне місце, і чи не зайнятий файл іншою програмою (наприклад, антивірусом), а потім запустіть інсталятор знову.</value>
+  </data>
+  <data name="CoreStoreRestoreFailed" xml:space="preserve">
+    <value>Не вдалося відновити {0}. Гра Fields of Mistria запущена? Закрийте її та спробуйте знову.</value>
+  </data>
+  <data name="CoreStoreBackupMissing" xml:space="preserve">
+    <value>{0} містить дані про попереднє встановлення, але резервна копія {1} відсутня. Будь ласка, перевірте цілісність файлів гри в Steam і спробуйте знову.</value>
+  </data>
+  <data name="CoreStoreUnreadableNoBackup" xml:space="preserve">
+    <value>Архів {0} не читається, а резервна копія {1} відсутня. Будь ласка, перевірте цілісність файлів гри в Steam і спробуйте знову.</value>
+  </data>
+  <data name="CoreStoreNoArchives" xml:space="preserve">
+    <value>Не вдалося знайти {0} або {1}. Запустіть гру принаймні один раз або перевірте цілісність файлів гри через Steam.</value>
+  </data>
+  <data name="CoreStoreNothingToUninstall" xml:space="preserve">
+    <value>Сховище ресурсів не знайдено, тому відновлювати нічого.</value>
+  </data>
+  <data name="CoreInstallSummary" xml:space="preserve">
+    <value>Встановлено модів: {0}</value>
+  </data>
+  <data name="CoreInstallSummaryWithSkipped" xml:space="preserve">
+    <value>Встановлено модів: {0}, пропущено: {1}</value>
+  </data>
+  <data name="CoreGameGmlChanged" xml:space="preserve">
+    <value>GML гри змінено. Встановлення неможливе.</value>
+  </data>
+  <data name="CoreModRequiresMissingHooks" xml:space="preserve">
+    <value>Мод потребує хуків (hooks), яких немає в цій версії MOMI: {0}. Оновіть MOMI або використовуйте старішу версію мода.</value>
+  </data>
+  <data name="CoreManifestRequiresHooksInvalid" xml:space="preserve">
+    <value>Параметр requires_hooks у маніфесті має бути масивом рядків з іменами хуків.</value>
+  </data>
+  <data name="CoreSkippedModReason" xml:space="preserve">
+    <value>Пропущено {0}: {1}</value>
+  </data>
+  <data name="CoreVerifyNoBackup" xml:space="preserve">
+    <value>Чиста резервна копія не знайдена в {0}. Запустіть інсталятор один раз для її створення або виконайте перевірку швів (seam check) безпосередньо із zip-архівом збірки.</value>
+  </data>
+  <data name="GUIUninstallCompleteText" xml:space="preserve">
+    <value>Видалення завершено</value>
+  </data>
+  <data name="GUIUninstallingText" xml:space="preserve">
+    <value>Видалення...</value>
+  </data>
+  <data name="GUIInstallFatalError" xml:space="preserve">
+    <value>Під час встановлення модів сталася критична помилка:</value>
+  </data>
+  <data name="GUIUninstallFatalError" xml:space="preserve">
+    <value>Під час видалення модів сталася критична помилка:</value>
+  </data>
+</root>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.uk.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.uk.resx
@@ -143,7 +143,7 @@
     <value>{0} вказує на спрайт у {1}, але цей файл не існує</value>
   </data>
   <data name="CoreSpriteFolderDoesNotExist" xml:space="preserve">
-    <value>{0} вказує на папку зі спрайтами в {1}, але ця директорія не існує</value>
+    <value>{0} вказує на папку зі спрайтами в {1}, але ця папка не існує</value>
   </data>
   <data name="CoreSpriteFolderIsEmpty" xml:space="preserve">
     <value>{0} вказує на папку зі спрайтами в {1}, але ця директорія порожня</value>


### PR DESCRIPTION
## Description
This PR introduces full **russian (ru)** and **Ukrainian (uk)** localizations. 

In addition to translating the base strings, a thorough QA and technical review was performed on the localization files to ensure consistency, correct UI tone, and technical stability.

## Key Changes
* **Added new localization files:** Created `.resx` files for russian and Ukrainian languages.
* **Fixed a string interpolation bug:** In the original English source (and initial translation drafts), the `CoreErrorReadingVersionForMod` key contained a typo: `(0)` instead of `{0}`. This has been corrected in these translations to prevent potential `String.Format` runtime errors or missing variable outputs.
* **Improved UI Clarity:** Modified the translations for `GUIEnableAllMods` and `GUIDisableAllMods` to explicitly state "Enable/Disable all **mods**" to remove any ambiguity in the interface.

## Testing
* [x] Verified that all XML tags are intact and valid.
* [x] Checked that all format placeholders (e.g., `{0}`, `{1}`) exactly match the source files to prevent crashes.

Thank you for building such a great tool! Let me know if any adjustments are needed.