### PR TITLE
Show actionable mod installation failures

### DIFF
--- a/ModsOfMistriaGUI/Controls/ModlistCheckbox.axaml
+++ b/ModsOfMistriaGUI/Controls/ModlistCheckbox.axaml
@@ -77,6 +77,17 @@
                     </Image>
 
                     <Image Height="16" Margin="5 0 0 0"
+                           IsVisible="{Binding WasFailed}">
+                        <ToolTip.Tip>
+                            <TextBlock Text="Installation failed for this mod" />
+                        </ToolTip.Tip>
+                        <Image.Source>
+                            <i:IconImage Value="fa-circle-xmark"
+                                         Brush="Red" />
+                        </Image.Source>
+                    </Image>
+
+                    <Image Height="16" Margin="5 0 0 0"
                            IsVisible="{Binding WasInstalled}">
                         <ToolTip.Tip>
                             <TextBlock Text="{x:Static lang:Resources.GUIModInstalled}" />

--- a/ModsOfMistriaGUI/Models/ModModel.cs
+++ b/ModsOfMistriaGUI/Models/ModModel.cs
@@ -13,6 +13,7 @@ public enum ModInstallState
     None,
     Installed,
     Skipped,
+    Failed,
 }
 
 public partial class ModModel : ObservableObject
@@ -68,6 +69,7 @@ public partial class ModModel : ObservableObject
 
     public bool WasInstalled      => _installState == ModInstallState.Installed;
     public bool WasSkipped        => _installState == ModInstallState.Skipped;
+    public bool WasFailed         => _installState == ModInstallState.Failed;
     public bool HasInstallOutcome => _installState != ModInstallState.None;
 
     // A skipped mod's reasons also land as validation errors; the red X and
@@ -86,6 +88,7 @@ public partial class ModModel : ObservableObject
         InstallDetail = detail;
         OnPropertyChanged(nameof(WasInstalled));
         OnPropertyChanged(nameof(WasSkipped));
+        OnPropertyChanged(nameof(WasFailed));
         OnPropertyChanged(nameof(HasInstallOutcome));
         OnPropertyChanged(nameof(InstallDetail));
         OnPropertyChanged(nameof(ShowErrorIcon));

--- a/ModsOfMistriaGUI/ViewModels/ModlistPageViewModel.cs
+++ b/ModsOfMistriaGUI/ViewModels/ModlistPageViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Reflection;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -431,6 +432,7 @@ public partial class ModlistPageViewModel : PageViewBase
     [RelayCommand(CanExecute = nameof(CanInstall))]
     private void InstallMods()
     {
+        Exception = "";
         // Auto-save profile state before installing so load order is persisted
         SaveCurrentProfileState();
 
@@ -452,6 +454,8 @@ public partial class ModlistPageViewModel : PageViewBase
         var files = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
         {
             Title           = Resources.GUIPickLogFile,
+            SuggestedFileName = $"momi-log-{DateTime.Now:yyyyMMdd-HHmmss}.txt",
+            DefaultExtension  = "txt",
             FileTypeChoices = [FilePickerFileTypes.TextPlain]
         });
 
@@ -499,14 +503,13 @@ public partial class ModlistPageViewModel : PageViewBase
             }
             catch (Exception e)
             {
-                // The failure surfaces globally and is TERMINAL for the session:
-                // the busy latch deliberately stays set, so installing,
-                // uninstalling and the list actions remain disabled under the
-                // error. Saving the log stays live - the error is a bug report.
+                var errorLogPath = WriteDiagnosticErrorLog("uninstall", e);
+                Logger.Log($"{Resources.GUIUninstallFatalError}\r\n{e}");
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
+                    IsInstalling  = false;
                     InstallStatus = "";
-                    Exception     = Resources.GUIUninstallFatalError + "\n" + e.Message;
+                    Exception     = FormatErrorMessage(Resources.GUIUninstallFatalError, e, errorLogPath);
                 });
             }
         });
@@ -548,15 +551,69 @@ public partial class ModlistPageViewModel : PageViewBase
         }
         catch (Exception e)
         {
-            // The failure surfaces globally and is TERMINAL for the session: the
-            // busy latch deliberately stays set, so installing, uninstalling and
-            // the list actions remain disabled under the error. Saving the log
-            // stays live - the error is a bug report.
+            var errorLogPath = WriteDiagnosticErrorLog("install", e);
+            Logger.Log($"{Resources.GUIInstallFatalError}\r\n{e}");
+            var failedModId = (e as ModInstallationException)?.ModId;
+
             Dispatcher.UIThread.InvokeAsync(() =>
             {
+                if (!string.IsNullOrEmpty(failedModId))
+                {
+                    var failedMod = Mods.FirstOrDefault(m =>
+                        string.Equals(m.Mod.GetId(), failedModId, StringComparison.OrdinalIgnoreCase));
+                    failedMod?.SetInstallOutcome(
+                        ModInstallState.Failed,
+                        e.Message + "\r\nReason: " + GetRootCauseMessage(e));
+                }
+
+                IsInstalling  = false;
                 InstallStatus = "";
-                Exception     = Resources.GUIInstallFatalError + "\n" + e.Message;
+                Exception     = FormatErrorMessage(Resources.GUIInstallFatalError, e, errorLogPath);
             });
+        }
+    }
+
+    private static string FormatErrorMessage(string heading, Exception exception, string? errorLogPath)
+    {
+        var rootCause = GetRootCauseMessage(exception);
+        var message = heading + "\n" + exception.Message;
+        if (!string.Equals(rootCause, exception.Message, StringComparison.Ordinal))
+            message += "\n\nReason: " + rootCause;
+        if (!string.IsNullOrEmpty(errorLogPath))
+            message += $"\n\nError details saved to:\n{errorLogPath}";
+        return message;
+    }
+
+    private static string GetRootCauseMessage(Exception exception)
+    {
+        while (exception.InnerException is not null)
+            exception = exception.InnerException;
+        return exception.Message;
+    }
+
+    private static string? WriteDiagnosticErrorLog(string operation, Exception exception)
+    {
+        try
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var root = string.IsNullOrWhiteSpace(localAppData) ? AppContext.BaseDirectory : localAppData;
+            var directory = Path.Combine(root, "MOMI", "logs");
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, $"momi-error-{DateTime.Now:yyyyMMdd-HHmmssfff}.txt");
+            var contents = $"MOMI diagnostic error log\r\n" +
+                           $"Timestamp (UTC): {DateTime.UtcNow:O}\r\n" +
+                           $"Application: {Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "unknown"}\r\n" +
+                           $"Operation: {operation}\r\n\r\n" +
+                           "Exception:\r\n" + exception + "\r\n\r\n" +
+                           "Recent MOMI log:\r\n" + string.Join("\r\n", Logger.GetLogs());
+            File.WriteAllText(path, contents, new System.Text.UTF8Encoding(false));
+            Logger.Log($"Diagnostic error log written to: {path}");
+            return path;
+        }
+        catch (Exception logException)
+        {
+            Logger.Log($"Could not write diagnostic error log: {logException.Message}");
+            return null;
         }
     }
 

--- a/ModsOfMistriaGUI/Views/ModlistPageView.axaml
+++ b/ModsOfMistriaGUI/Views/ModlistPageView.axaml
@@ -70,7 +70,7 @@
             </StackPanel>
 
             <!-- Mod list -->
-            <ScrollViewer Margin="15 5 0 0" IsVisible="{Binding !Exception.Length}">
+            <ScrollViewer Margin="15 5 0 0">
                 <ItemsRepeater ItemsSource="{Binding Mods}" x:Name="ModRepeater">
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate>

--- a/ModsOfMistriaInstallerLib/Lang/Resources.resx
+++ b/ModsOfMistriaInstallerLib/Lang/Resources.resx
@@ -490,9 +490,9 @@
     <value>Uninstalling</value>
   </data>
   <data name="GUIInstallFatalError" xml:space="preserve">
-    <value>A fatal error occurred during mod installation:</value>
+    <value>Installation failed; no archive changes were committed:</value>
   </data>
   <data name="GUIUninstallFatalError" xml:space="preserve">
-    <value>A fatal error occurred during mod uninstallation:</value>
+    <value>Uninstallation failed; no archive changes were committed:</value>
   </data>
 </root>

--- a/ModsOfMistriaInstallerLib/ModInstaller.cs
+++ b/ModsOfMistriaInstallerLib/ModInstaller.cs
@@ -14,6 +14,17 @@ using Microsoft.Win32;
 
 namespace Garethp.ModsOfMistriaInstallerLib;
 
+public sealed class ModInstallationException : InvalidOperationException
+{
+    public string ModId { get; }
+
+    public ModInstallationException(string modId, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ModId = modId;
+    }
+}
+
 // Coordinates mod installation and uninstallation.
 // Delegates file-type-specific work to Installer subclasses.
 public class ModInstaller
@@ -130,7 +141,17 @@ public class ModInstaller
             var modTimer = Stopwatch.StartNew();
             reportStatus($"Installing {mod.GetName()} {mod.GetVersion()} by {mod.GetAuthor()}", "");
 
-            RunInstallers(mod, fileNameUIDMapping, atlasUtils, reportStatus, phase);
+            try
+            {
+                RunInstallers(mod, fileNameUIDMapping, atlasUtils, reportStatus, phase);
+            }
+            catch (Exception exception)
+            {
+                throw new ModInstallationException(
+                    mod.GetId(),
+                    $"Mod '{mod.GetName()}' v{mod.GetVersion()} by {mod.GetAuthor()} failed during installation.",
+                    exception);
+            }
 
             modTimer.Stop();
             reportStatus($"Finished {mod.GetName()}", modTimer.Elapsed.ToString());

--- a/ModsOfMistriaInstallerLib/ModInstaller.cs
+++ b/ModsOfMistriaInstallerLib/ModInstaller.cs
@@ -37,6 +37,12 @@ public class ModInstaller
         if (!Directory.Exists(_fomLocation))
             throw new DirectoryNotFoundException(Resources.CoreMistriaLocationDoesNotExist);
 
+        // Reject malformed source TOML before creating or replacing any game
+        // archive. The source mod and relative path are part of the error so
+        // users can fix the correct file instead of guessing from a merge
+        // stack trace.
+        TomlFileValidator.ValidateMods(mods);
+
         // Coarse progress for a status line: the current mod (or "" for a
         // whole-install step) and the phase it is in. reportStatus stays the
         // verbose per-file channel.
@@ -94,8 +100,10 @@ public class ModInstaller
             installMods = mods.Where(m => !excludedMods.Contains(m)).ToList();
         }
 
-        _fileModifier = store.BeginRebuild();
-        _fileModifier.Write("manifest.toml", "");
+        try
+        {
+            _fileModifier = store.BeginRebuild();
+            _fileModifier.Write("manifest.toml", "");
 
         if (plan is not null)
         {
@@ -132,7 +140,7 @@ public class ModInstaller
         atlasUtils.Flush();
 
         phase("", "Writing game archive");
-        store.Commit();
+            store.Commit(installMods.Select(mod => new InstalledModState(mod.GetId(), mod.GetVersion())));
 
         // After the archive commits, so the Mods tab never describes an
         // archive that failed to land. The Mods tab lists exactly what runs (D12).
@@ -141,8 +149,14 @@ public class ModInstaller
         totalTime.Stop();
         reportStatus(Resources.CoreInstallCompleted, totalTime.Elapsed.ToString());
 
-        result.Installed.AddRange(installMods);
-        return result;
+            result.Installed.AddRange(installMods);
+            return result;
+        }
+        catch
+        {
+            store.Abort();
+            throw;
+        }
     }
 
     private GmlLayerPlan StageGmlLayer(AssetsStore store, List<GmlModCode> gmlMods,

--- a/ModsOfMistriaInstallerLib/Store/AssetsStore.cs
+++ b/ModsOfMistriaInstallerLib/Store/AssetsStore.cs
@@ -1,141 +1,393 @@
 using System.IO.Compression;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 using Garethp.ModsOfMistriaInstallerLib.Lang;
 using Garethp.ModsOfMistriaInstallerLib.Utils;
+using Tomlyn;
+using Tomlyn.Model;
 
 namespace Garethp.ModsOfMistriaInstallerLib.Store;
 
-// The two-file assets store: assets.zip is live (the game loads it) and
-// assets.bak.zip is pristine. Every install is a whole-archive rebuild from
-// pristine: copy the backup over the live archive, write both layers into it
-// in update mode, commit on dispose. No temp file and no atomic swap; a crash
-// mid-install leaves the complete vanilla copy on disk (update mode buffers in
-// memory), and the copy and flush windows stay a known risk (D4).
+public sealed record InstalledModState(string Id, string Version);
+
+// Owns the assets.zip transaction. The live archive is never opened for
+// writing: every install is rebuilt from a verified pristine archive into a
+// same-directory temporary archive and published only after validation.
 public class AssetsStore(string fomLocation)
 {
     private ZipArchive? _archive;
+    private string? _temporaryPath;
 
     public string LivePath { get; } = Path.Combine(fomLocation, "assets.zip");
-
     public string BackupPath { get; } = Path.Combine(fomLocation, "assets.bak.zip");
+    public string TemporaryPath { get; } = Path.Combine(fomLocation, "assets.momi.tmp.zip");
+    public string StatePath { get; } = Path.Combine(fomLocation, "assets.momi.state.toml");
 
-    // What the live archive tells us. Unreadable is its own state, never
-    // unmarked: the unmarked branch copies the live archive over the backup,
-    // which against a truncated archive would destroy the only pristine copy.
-    private enum LiveState
-    {
-        Absent,
-        Unmarked,
-        Marked,
-        Unreadable,
-    }
+    private enum LiveState { Absent, Unmarked, Marked, Unreadable }
 
-    // Make sure assets.bak.zip is the pristine source before anything writes.
-    // An unmarked live archive is vanilla (fresh install, or the game
-    // updated) → copy it over the backup. A marked or unreadable one needs the
-    // backup already there; a missing pair means no game assets at all.
     public void EnsureBackup()
     {
-        switch (ReadLiveState())
+        var backupHash = EnsureReadableBackup();
+        var state = ReadState();
+        var liveState = ReadLiveState();
+
+        if (state is not null && backupHash is null)
+            throw new InvalidOperationException(string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
+
+        if (state is not null && backupHash != state.PristineSha256)
+            throw new InvalidOperationException("The MOMI state file does not match the verified pristine archive; the backup was preserved.");
+
+        if (liveState == LiveState.Absent)
         {
-            case LiveState.Unmarked:
-                File.Copy(LivePath, BackupPath, true);
-                return;
-            case LiveState.Marked when !File.Exists(BackupPath):
-                throw new InvalidOperationException(
-                    string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
-            case LiveState.Unreadable when !File.Exists(BackupPath):
-                throw new InvalidOperationException(
-                    string.Format(Resources.CoreStoreUnreadableNoBackup, LivePath, BackupPath));
-            case LiveState.Absent when !File.Exists(BackupPath):
-                throw new FileNotFoundException(
-                    string.Format(Resources.CoreStoreNoArchives, LivePath, BackupPath), LivePath);
+            if (backupHash is null)
+                throw new FileNotFoundException(string.Format(Resources.CoreStoreNoArchives, LivePath, BackupPath), LivePath);
+            return;
         }
+
+        if (liveState == LiveState.Unreadable)
+        {
+            if (backupHash is null)
+                throw new InvalidOperationException(string.Format(Resources.CoreStoreUnreadableNoBackup, LivePath, BackupPath));
+            return;
+        }
+
+        var liveHash = Sha256File(LivePath);
+        if (state is not null)
+        {
+            if (liveHash == state.GeneratedLiveSha256 || liveHash == state.PristineSha256)
+                return;
+
+            throw UnknownLiveArchive(liveHash, state);
+        }
+
+        // Legacy installs have no state file. An unmarked live archive is the
+        // only safe legacy signal that it is vanilla; establish the backup.
+        // Once state exists, the branch above refuses to overwrite a verified
+        // pristine archive merely because manifest.toml is absent.
+        if (liveState == LiveState.Unmarked)
+        {
+            CopyVerified(LivePath, BackupPath);
+            return;
+        }
+
+        if (backupHash is null)
+            throw new InvalidOperationException(string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
     }
 
-    // Copy the backup over the live archive and open it for the rebuild. The
-    // copy is the first write action, so a running game fails here with the
-    // previous install still live. The open sits in the same guard: a game
-    // launched after the copy still holds the file when Update acquires it.
     public IFileModifier BeginRebuild()
     {
+        EnsureReadableBackup();
+        Abort();
+
         try
         {
-            File.Copy(BackupPath, LivePath, true);
-            _archive = ZipFile.Open(LivePath, ZipArchiveMode.Update);
+            File.Copy(BackupPath, TemporaryPath, true);
+            _temporaryPath = TemporaryPath;
+            _archive = ZipFile.Open(TemporaryPath, ZipArchiveMode.Update);
+            return new ZipFileModifier(_archive);
         }
         catch (IOException exception) when (exception is not FileNotFoundException)
         {
+            Abort();
             throw new IOException(string.Format(Resources.CoreStoreRebuildFailed, LivePath), exception);
         }
-
-        return new ZipFileModifier(_archive);
     }
 
-    // Dispose the archive, which is the flush. A failure here leaves the
-    // bootable vanilla copy on disk; re-running the installer heals it.
-    public void Commit()
+    public void Commit() => Commit([]);
+
+    public void Commit(IEnumerable<InstalledModState> installedMods)
     {
-        if (_archive is null)
+        if (_archive is null || _temporaryPath is null)
             throw new InvalidOperationException("Commit without BeginRebuild");
 
         try
         {
             _archive.Dispose();
+            _archive = null;
+
+            ValidateArchive(_temporaryPath);
+            var pristineHash = Sha256File(BackupPath);
+            var generatedHash = Sha256File(_temporaryPath);
+            var stateText = SerializeState(pristineHash, generatedHash, installedMods);
+            Toml.ParseToml(stateText);
+            var stateTemp = StatePath + ".tmp";
+            SafeDelete(stateTemp);
+            WriteExclusiveReplacement(stateTemp, stateText);
+
+            AtomicReplace(_temporaryPath, LivePath);
+            _temporaryPath = null;
+
+            AtomicReplace(stateTemp, StatePath);
         }
-        catch (IOException exception)
+        catch (IOException exception) when (_archive is null)
         {
+            CleanupTemporary();
+            SafeDelete(StatePath + ".tmp");
             throw new IOException(string.Format(Resources.CoreStoreFlushFailed, LivePath), exception);
         }
-        finally
+        catch
         {
-            _archive = null;
+            Abort();
+            SafeDelete(StatePath + ".tmp");
+            throw;
         }
     }
 
-    // The uninstall guard ladder (D15). Unmarked → the game updated or nothing
-    // was ever installed, so clean up the stale backup instead of copying old
-    // game files over new ones. Marked or unreadable → restore the pristine
-    // copy, refusing when there is none. True when the store changed.
+    public void Abort()
+    {
+        try { _archive?.Dispose(); } catch { /* best effort; live is untouched */ }
+        _archive = null;
+        CleanupTemporary();
+    }
+
     public bool Uninstall()
     {
-        var state = ReadLiveState();
-        switch (state)
+        var backupHash = EnsureReadableBackup();
+        var state = ReadState();
+        var liveState = ReadLiveState();
+
+        if (state is not null && backupHash is null)
+            throw new InvalidOperationException(string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
+        if (state is not null && backupHash != state.PristineSha256)
+            throw new InvalidOperationException("The MOMI state file does not match the verified pristine archive; the backup was preserved.");
+
+        if (liveState == LiveState.Absent)
         {
-            case LiveState.Unmarked:
-                if (File.Exists(BackupPath)) File.Delete(BackupPath);
-                return true;
-            case LiveState.Absent when !File.Exists(BackupPath):
+            if (backupHash is null)
+            {
                 Logger.Log(Resources.CoreStoreNothingToUninstall);
                 return false;
-            case LiveState.Marked or LiveState.Unreadable when !File.Exists(BackupPath):
-                throw new InvalidOperationException(
-                    string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
+            }
+            RestoreBackupTransactionally();
+            if (state is null) RemoveState();
+            else WritePristineState(backupHash!);
+            return true;
         }
 
+        if (liveState == LiveState.Unmarked && state is null)
+        {
+            // A legacy unmarked archive is treated as vanilla. Keep the
+            // live archive and remove only the legacy, untracked backup.
+            if (File.Exists(BackupPath)) File.Delete(BackupPath);
+            return true;
+        }
+
+        if (backupHash is null)
+            throw new InvalidOperationException(string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
+
+        if (state is not null && (liveState is LiveState.Unmarked or LiveState.Marked))
+        {
+            var liveHash = Sha256File(LivePath);
+            if (liveHash != state.GeneratedLiveSha256 && liveHash != state.PristineSha256)
+                throw UnknownLiveArchive(liveHash, state);
+        }
+
+        if (state is null && liveState == LiveState.Marked && backupHash is null)
+            throw new InvalidOperationException(string.Format(Resources.CoreStoreBackupMissing, LivePath, BackupPath));
+
+        RestoreBackupTransactionally();
+        if (state is null) RemoveState();
+        else WritePristineState(backupHash);
+        return true;
+    }
+
+    private void RestoreBackupTransactionally()
+    {
+        EnsureReadableBackup();
+        Abort();
+        File.Copy(BackupPath, TemporaryPath, true);
         try
         {
-            File.Copy(BackupPath, LivePath, true);
+            ValidateArchive(TemporaryPath);
+            AtomicReplace(TemporaryPath, LivePath);
         }
-        catch (IOException exception) when (exception is not FileNotFoundException)
+        catch (IOException exception)
         {
+            CleanupTemporary();
             throw new IOException(string.Format(Resources.CoreStoreRestoreFailed, LivePath), exception);
         }
+    }
 
-        return true;
+    private string? EnsureReadableBackup()
+    {
+        if (!File.Exists(BackupPath)) return null;
+        ValidateArchive(BackupPath);
+        return Sha256File(BackupPath);
     }
 
     private LiveState ReadLiveState()
     {
         if (!File.Exists(LivePath)) return LiveState.Absent;
-
         try
         {
+            ValidateArchive(LivePath);
             using var archive = ZipFile.OpenRead(LivePath);
             return archive.GetEntry("manifest.toml") is null ? LiveState.Unmarked : LiveState.Marked;
         }
-        catch (InvalidDataException)
+        catch (InvalidDataException) { return LiveState.Unreadable; }
+        catch (IOException) { return LiveState.Unreadable; }
+    }
+
+    private StoreState? ReadState()
+    {
+        if (!File.Exists(StatePath)) return null;
+        try
         {
-            return LiveState.Unreadable;
+            var root = Toml.ParseToml(File.ReadAllText(StatePath));
+            if (!root.TryGetValue("schema_version", out var schema) || schema is not long version || version != 1)
+                throw new FormatException("Unsupported state schema version");
+            return new StoreState(
+                GetString(root, "pristine_sha256"),
+                GetString(root, "generated_live_sha256"));
+        }
+        catch (Exception exception) when (exception is FormatException or IOException or TomlException)
+        {
+            throw new InvalidOperationException($"MOMI state file is invalid: {StatePath}", exception);
         }
     }
+
+    private static string GetString(TomlTable root, string key) =>
+        root.TryGetValue(key, out var value) && value is string text && !string.IsNullOrWhiteSpace(text)
+            ? text
+            : throw new FormatException($"Missing state field '{key}'");
+
+    private string SerializeState(string pristineHash, string generatedHash, IEnumerable<InstalledModState> installedMods)
+    {
+        var root = new TomlTable
+        {
+            ["schema_version"] = 1L,
+            ["pristine_sha256"] = pristineHash,
+            ["generated_live_sha256"] = generatedHash,
+            ["momi_version"] = Assembly.GetEntryAssembly()?.GetName().Version?.ToString()
+                               ?? GetType().Assembly.GetName().Version?.ToString() ?? "unknown",
+            ["installed_at_utc"] = DateTimeOffset.UtcNow.ToString("O"),
+        };
+        var mods = new TomlTableArray();
+        foreach (var mod in installedMods.OrderBy(m => m.Id, StringComparer.Ordinal))
+            mods.Add(new TomlTable { ["id"] = mod.Id, ["version"] = mod.Version });
+        root["mods"] = mods;
+        return TomlSerializer.Serialize(root);
+    }
+
+    private static void ValidateArchive(string path)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        var normalized = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var hasAssets = false;
+        foreach (var entry in archive.Entries)
+        {
+            var name = entry.FullName.Replace('\\', '/');
+            var key = name.TrimEnd('/');
+            if (key.Length == 0 || !normalized.Add(key))
+                throw new InvalidDataException($"Archive contains a duplicate or invalid normalized path: {entry.FullName}");
+            if (name.StartsWith("assets/", StringComparison.OrdinalIgnoreCase)) hasAssets = true;
+
+            using var input = entry.Open();
+            input.CopyTo(Stream.Null); // verifies the entry CRC while reading
+
+            if (name.EndsWith(".toml", StringComparison.OrdinalIgnoreCase))
+            {
+                using var text = entry.Open();
+                using var reader = new StreamReader(text, new UTF8Encoding(false, true), detectEncodingFromByteOrderMarks: true);
+                try
+                {
+                    Toml.ParseToml(reader.ReadToEnd());
+                }
+                catch (Exception exception) when (exception is TomlException or FormatException)
+                {
+                    throw new InvalidDataException($"Invalid TOML in archive entry '{name}'.", exception);
+                }
+            }
+        }
+        if (!hasAssets) throw new InvalidDataException("Archive contains no assets/ game entries");
+    }
+
+    private static void CopyVerified(string source, string destination)
+    {
+        ValidateArchive(source);
+        var temp = destination + ".tmp";
+        SafeDelete(temp);
+        try
+        {
+            File.Copy(source, temp, false);
+            AtomicReplace(temp, destination);
+            if (Sha256File(source) != Sha256File(destination))
+                throw new IOException("Pristine archive hash verification failed");
+        }
+        finally
+        {
+            SafeDelete(temp);
+        }
+    }
+
+    private void WritePristineState(string pristineHash)
+    {
+        var stateTemp = StatePath + ".tmp";
+        SafeDelete(stateTemp);
+        var stateText = SerializeState(pristineHash, pristineHash, []);
+        Toml.ParseToml(stateText);
+        WriteExclusiveReplacement(stateTemp, stateText);
+        AtomicReplace(stateTemp, StatePath);
+    }
+
+    private static void WriteExclusiveReplacement(string path, string text) =>
+        WriteExclusiveReplacement(path, Encoding.UTF8.GetBytes(text));
+
+    private static void WriteExclusiveReplacement(string path, byte[] bytes)
+    {
+        using var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        stream.Write(bytes);
+        stream.Flush(true);
+    }
+
+    private static void SafeDelete(string path)
+    {
+        if (!File.Exists(path)) return;
+        File.Delete(path);
+    }
+
+    private static void AtomicReplace(string source, string destination)
+    {
+        try
+        {
+            if (File.Exists(destination))
+                File.Replace(source, destination, null, ignoreMetadataErrors: true);
+            else
+                File.Move(source, destination);
+        }
+        catch (PlatformNotSupportedException)
+        {
+            File.Move(source, destination, overwrite: true);
+        }
+        catch (IOException) when (!File.Exists(destination))
+        {
+            File.Move(source, destination);
+        }
+    }
+
+    private void CleanupTemporary()
+    {
+        _temporaryPath = null;
+        if (File.Exists(TemporaryPath))
+        {
+            try { File.Delete(TemporaryPath); } catch { /* next run reports a stale temp */ }
+        }
+    }
+
+    private void RemoveState()
+    {
+        if (File.Exists(StatePath)) File.Delete(StatePath);
+    }
+
+    private static string Sha256File(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
+
+    private static InvalidOperationException UnknownLiveArchive(string liveHash, StoreState state) =>
+        new($"The live assets archive is not the known MOMI output or pristine archive (SHA-256 {liveHash}); possible game update or external modification. The verified backup was preserved. Reinstall/verify the game before retrying.");
+
+    private sealed record StoreState(string PristineSha256, string GeneratedLiveSha256);
 }

--- a/ModsOfMistriaInstallerLib/Utils/TomlFileValidator.cs
+++ b/ModsOfMistriaInstallerLib/Utils/TomlFileValidator.cs
@@ -1,0 +1,33 @@
+using Garethp.ModsOfMistriaInstallerLib.ModTypes;
+using Tomlyn;
+
+namespace Garethp.ModsOfMistriaInstallerLib.Utils;
+
+/// <summary>
+/// Validates TOML supplied by a mod before the archive transaction starts.
+/// Keeping this separate from the installers makes the error point to the
+/// source mod file rather than to whichever merge operation happened to read
+/// it first.
+/// </summary>
+public static class TomlFileValidator
+{
+    public static void ValidateMods(IEnumerable<IMod> mods)
+    {
+        foreach (var mod in mods)
+        {
+            foreach (var path in mod.GetAllFiles(".toml").Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    Toml.ParseToml(mod.ReadFile(path));
+                }
+                catch (Exception exception) when (exception is TomlException or FormatException)
+                {
+                    throw new InvalidDataException(
+                        $"Invalid TOML in mod '{mod.GetName()}' ({mod.GetId()}), file '{path}'.",
+                        exception);
+                }
+            }
+        }
+    }
+}

--- a/ModsOfMistriaInstallerLib/Utils/ZipFileModifier.cs
+++ b/ModsOfMistriaInstallerLib/Utils/ZipFileModifier.cs
@@ -1,10 +1,14 @@
 ﻿using System.IO.Compression;
 using SixLabors.ImageSharp.Advanced;
+using System.Text;
 
 namespace Garethp.ModsOfMistriaInstallerLib.Utils;
 
 public class ZipFileModifier(ZipArchive archive) : IFileModifier
 {
+    private static readonly DateTimeOffset DeterministicEntryTime =
+        new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
     private ZipArchive _archive = archive;
 
     public bool Exists(string file)
@@ -49,11 +53,9 @@ public class ZipFileModifier(ZipArchive archive) : IFileModifier
 
     public void Write(string file, string contents)
     {
-        var stream = GetWriteStream(file);
-        stream.SetLength(contents.Length);
-        using var writer = new StreamWriter(stream);
-        writer.Write(contents);
-        writer.Close();
+        // String length is UTF-16 code units, not the UTF-8 byte count used by
+        // the archive entry. Direct byte writes preserve Cyrillic text.
+        Write(file, Encoding.UTF8.GetBytes(contents));
     }
 
     public void Write(string file, byte[] contents)
@@ -70,7 +72,12 @@ public class ZipFileModifier(ZipArchive archive) : IFileModifier
         file = file.Replace('\\', '/');
         var entry = _archive.GetEntry(file);
         if (entry == null)
+        {
             entry = _archive.CreateEntry(file);
+            // Mod-generated entries must not receive the current clock time;
+            // otherwise identical rebuilds produce different ZIP bytes.
+            entry.LastWriteTime = DeterministicEntryTime;
+        }
         
         var stream = entry.Open();
         return stream;

--- a/ModsOfMistriaInstallerLibTests/ModInstallerTest.cs
+++ b/ModsOfMistriaInstallerLibTests/ModInstallerTest.cs
@@ -199,6 +199,23 @@ public class ModInstallerTest
             new ModInstaller(Path.Combine(_fom, "not-there"), "").InstallMods([], (_, _) => { }));
     }
 
+    [Test]
+    public void ShouldIdentifyTheSourceFileWhenModTomlIsInvalid()
+    {
+        var mod = new MockMod(new Dictionary<string, string>
+        {
+            ["data/broken.toml"] = "broken = [toml"
+        }) { Id = "broken.mod", Name = "Broken Mod" };
+
+        var exception = Assert.Throws<InvalidDataException>(() =>
+            new ModInstaller(_fom, "").InstallMods([mod], (_, _) => { }));
+
+        Assert.That(exception!.Message, Does.Contain("Broken Mod"));
+        Assert.That(exception.Message, Does.Contain("data/broken.toml"));
+        Assert.That(File.Exists(new AssetsStore(_fom).BackupPath), Is.False,
+            "source validation must happen before creating a pristine backup");
+    }
+
     // ── Fixtures and helpers ───────────────────────────────────────────────────
 
     private static MockMod GmlMod(string id, List<string>? requiresHooks = null) =>

--- a/ModsOfMistriaInstallerLibTests/Store/AssetsStoreTest.cs
+++ b/ModsOfMistriaInstallerLibTests/Store/AssetsStoreTest.cs
@@ -2,6 +2,7 @@ using System.IO.Compression;
 using System.Security.Cryptography;
 using System.Text;
 using Garethp.ModsOfMistriaInstallerLib.Store;
+using Tomlyn;
 
 namespace ModsOfMistriaInstallerLibTests.Store;
 
@@ -210,7 +211,7 @@ public class AssetsStoreTest
     // handle never blocks the rebuild there
     [Test]
     [Platform("Win")]
-    public void ShouldFailInBeginRebuildWithTheRunningGameHint()
+    public void ShouldKeepLiveArchiveUntouchedUntilCommitAndFailSafelyWhenLocked()
     {
         WriteInstalledLive();
         WriteVanillaBackup();
@@ -221,23 +222,25 @@ public class AssetsStoreTest
 
         using (File.Open(LivePath, FileMode.Open, FileAccess.Read, FileShare.Read))
         {
-            var exception = Assert.Throws<IOException>(() => store.BeginRebuild());
-            Assert.That(exception!.Message, Does.Contain("running"));
+            var modifier = store.BeginRebuild();
+            modifier.Write("assets/gml/scripts/example_mod/State.gml", Encoding.UTF8.GetBytes("// staged\n"));
+            Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(before));
+            Assert.Throws<IOException>(() => store.Commit());
         }
 
         Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(before));
+        Assert.That(File.Exists(Path.Combine(_fom, "assets.momi.tmp.zip")), Is.False);
     }
 
     // Windows-only: Unix does not enforce FileShare semantics, so an open
     // handle never blocks the rebuild there
     [Test]
     [Platform("Win")]
-    public void ShouldCarryTheRunningGameHintWhenTheOpenIsBlocked()
+    public void ShouldStageEvenWhenLiveArchiveAllowsSharedReads()
     {
-        // a game launched between the copy and the open: this handle's share
-        // lets File.Copy succeed but blocks ZipFile.Open's Update mode
         WriteInstalledLive();
         WriteVanillaBackup();
+        var before = File.ReadAllBytes(LivePath);
 
         var store = new AssetsStore(_fom);
         store.EnsureBackup();
@@ -245,12 +248,12 @@ public class AssetsStoreTest
         using (File.Open(LivePath, FileMode.Open, FileAccess.Read,
                    FileShare.ReadWrite | FileShare.Delete))
         {
-            var exception = Assert.Throws<IOException>(() => store.BeginRebuild());
-            Assert.That(exception!.Message, Does.Contain("running"));
+            store.BeginRebuild();
+            Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(before));
+            store.Abort();
         }
 
-        // the copy itself went through, so the failure was the open's
-        Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(File.ReadAllBytes(BackupPath)));
+        Assert.That(File.Exists(Path.Combine(_fom, "assets.momi.tmp.zip")), Is.False);
     }
 
     // The Unix mirror of the two tests above: .NET's advisory locks make the
@@ -292,6 +295,7 @@ public class AssetsStoreTest
         modifier.Write("assets/gml/scripts/example_mod/State.gml", Encoding.UTF8.GetBytes("// state\n"));
         store.Commit();
         var first = EntryHashes(LivePath);
+        var firstBytes = File.ReadAllBytes(LivePath);
 
         store = new AssetsStore(_fom);
         store.EnsureBackup();
@@ -301,6 +305,7 @@ public class AssetsStoreTest
         store.Commit();
 
         Assert.That(EntryHashes(LivePath), Is.EqualTo(first));
+        Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(firstBytes));
     }
 
     [Test]
@@ -378,6 +383,114 @@ public class AssetsStoreTest
 
         Assert.That(restored, Is.False);
         Assert.That(File.Exists(LivePath), Is.False);
+    }
+
+    [Test]
+    public void ShouldWriteTransactionalStateWithInstalledMods()
+    {
+        WriteVanillaLive();
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        var modifier = store.BeginRebuild();
+        modifier.Write("manifest.toml", "");
+        store.Commit([new("example.mod", "1.2.3")]);
+
+        Assert.That(File.Exists(Path.Combine(_fom, "assets.momi.state.toml")), Is.True);
+        var state = File.ReadAllText(Path.Combine(_fom, "assets.momi.state.toml"));
+        Assert.That(state, Does.Contain("pristine_sha256"));
+        Assert.That(state, Does.Contain("generated_live_sha256"));
+        Assert.That(state, Does.Contain("example.mod"));
+        Assert.That(state, Does.Contain("1.2.3"));
+    }
+
+    [Test]
+    public void ShouldRefuseAnUnknownUnmarkedArchiveAfterAKnownInstall()
+    {
+        WriteVanillaLive();
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        var modifier = store.BeginRebuild();
+        modifier.Write("manifest.toml", "");
+        store.Commit();
+        var backupBefore = File.ReadAllBytes(BackupPath);
+
+        WriteZip(LivePath, ("assets/gml/objects/Game.gml", "new game build\n"));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new AssetsStore(_fom).EnsureBackup());
+        Assert.That(exception!.Message, Does.Contain("game update or external modification"));
+        Assert.That(File.ReadAllBytes(BackupPath), Is.EqualTo(backupBefore));
+    }
+
+    [Test]
+    public void ShouldKeepLiveArchiveWhenStagedTomlIsInvalid()
+    {
+        WriteVanillaLive();
+        var before = File.ReadAllBytes(LivePath);
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        var modifier = store.BeginRebuild();
+        modifier.Write("assets/bad.toml", "not = [valid");
+
+        var exception = Assert.Throws<InvalidDataException>(() => store.Commit());
+        Assert.That(exception!.Message, Does.Contain("assets/bad.toml"));
+        Assert.That(File.ReadAllBytes(LivePath), Is.EqualTo(before));
+        Assert.That(File.Exists(Path.Combine(_fom, "assets.momi.tmp.zip")), Is.False);
+    }
+
+    [Test]
+    public void ShouldPreserveUtf8TextInStagedEntries()
+    {
+        WriteVanillaLive();
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        var modifier = store.BeginRebuild();
+        modifier.Write("assets/localization/test.txt", "Български тест");
+        store.Commit();
+
+        Assert.That(ReadEntries(LivePath)["assets/localization/test.txt"],
+            Is.EqualTo(Encoding.UTF8.GetBytes("Български тест")));
+    }
+
+    [Test]
+    public void ShouldReplaceStaleOwnedTemporaryArchiveBeforeRebuild()
+    {
+        WriteVanillaLive();
+        File.WriteAllText(Path.Combine(_fom, "assets.momi.tmp.zip"), "stale");
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        Assert.DoesNotThrow(() => store.BeginRebuild());
+        store.Abort();
+        Assert.That(File.Exists(Path.Combine(_fom, "assets.momi.tmp.zip")), Is.False);
+    }
+
+    [Test]
+    public void ShouldRejectDuplicateNormalizedArchivePaths()
+    {
+        WriteVanillaLive();
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+
+        using (var archive = ZipFile.Open(BackupPath, ZipArchiveMode.Update))
+            using (var stream = archive.CreateEntry("assets\\gml\\objects\\Game.gml").Open())
+                stream.Write(Encoding.UTF8.GetBytes("duplicate\n"));
+
+        Assert.Throws<InvalidDataException>(() => new AssetsStore(_fom).EnsureBackup());
+    }
+
+    [Test]
+    public void ShouldRejectAStateFileThatDoesNotMatchThePristineBackup()
+    {
+        WriteVanillaLive();
+        var store = new AssetsStore(_fom);
+        store.EnsureBackup();
+        var modifier = store.BeginRebuild();
+        modifier.Write("manifest.toml", "");
+        store.Commit();
+
+        WriteZip(BackupPath, ("assets/gml/objects/Game.gml", "different pristine\n"));
+
+        var exception = Assert.Throws<InvalidOperationException>(() => new AssetsStore(_fom).EnsureBackup());
+        Assert.That(exception!.Message, Does.Contain("does not match"));
     }
 
 }


### PR DESCRIPTION
## Scope

This is the second focused PR in the series and is based on #145 (`Harden assets archive transactions`). Please review commit `b2974f4` as the incremental change and merge #145 first.

It improves the failure path after a mod installer throws:

- identifies the exact mod that failed, including version and author;
- marks that mod with a failed indicator and retains the reason in the list;
- writes a diagnostic error log under the user's local MOMI log directory;
- preserves the staged-archive guarantee that no live archive changes are committed;
- clears the busy state so the user can retry, uninstall, or inspect the list without restarting;
- keeps the mod list visible instead of replacing it with a terminal error page;
- adds a user-editable suggested filename and `.txt` extension when exporting the regular log.

The same diagnostic/recovery behavior is applied to uninstall failures. No localization implementation or profile/load-order changes are included.

## Validation

- `dotnet build ModsOfMistriaGUI/ModsOfMistriaGUI.csproj --no-restore --verbosity quiet`
- `dotnet test ModsOfMistriaInstallerLibTests/ModsOfMistriaInstallerLibTests.csproj --no-restore --verbosity quiet`
- Result: build succeeded; 306 passed, 26 skipped, 332 total.