### PR TITLE
Fix build issue with .NET and C# version

### DIFF
--- a/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
+++ b/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
+++ b/ModsOfMistriaCommandLine/ModsOfMistriaCommandLine.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>14.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>

--- a/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
+++ b/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>14.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <PublishSingleFile>true</PublishSingleFile>

--- a/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
+++ b/ModsOfMistriaGUI/ModsOfMistriaGUI.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/ModsOfMistriaGUITests/ModsOfMistriaGUITests.csproj
+++ b/ModsOfMistriaGUITests/ModsOfMistriaGUITests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
+++ b/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
+++ b/ModsOfMistriaInstallerLib/ModsOfMistriaInstallerLib.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>14.0</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Garethp.ModsOfMistriaInstallerLib</RootNamespace>

--- a/ModsOfMistriaInstallerLibTests/ModsOfMistriaInstallerLibTests.csproj
+++ b/ModsOfMistriaInstallerLibTests/ModsOfMistriaInstallerLibTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": true
   }


### PR DESCRIPTION
Fixes the version of .NET: the getter/setter used are only available starting C# 14. I changed it to .NET 10 latest C# for ease of build.