### PR TITLE
MMAPI hooks for museum, player, quest, renown, and UI

### DIFF
--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -37,7 +37,7 @@ version = 2
 # shipped-catalog test also holds the docs' count sentences to these numbers.
 [counts]
 hooks = 113
-seams = 123
+seams = 121
 engine_fixes = 3
 call_rewrites = 1
 
@@ -374,12 +374,17 @@ doc  = "Fires every frame for every monster in par_monster's begin step, right a
 [[hook]]
 name = "museum.donate_item"
 kind = "event"
-doc = "Fires at the top of donate_item_to_museum(), before the item is registered to the museum. ctx is { item_id }." 
+doc  = "Fires at the top of donate_item_to_museum(), before the item is registered to the collection and before the pending renown entry is pushed. ctx is { item_id }. Observation only - the DonationResult the function goes on to compute (progress, completed set, rewards) is decided after the emit. Fires once per donated item, from the museum donation menu and the engine's test suite; save load and the ALL_UNLOCKS new-game path write donations through register_item_to_museum() directly and never fire this hook."
 
 [[hook]]
 name = "player.acquire_perk"
 kind = "event"
-doc  = "Fires at the top of acquire_perk(). ctx is perk, as the perk id"
+doc  = "Fires at the top of Ari.acquire_perk(perk), before the perk is flagged owned and active and before its acquisition side effects (the Guardian's Shield extra invulnerable hit, the Ancient Inspiration timer reset) run. ctx is { perk }, the Perk enum id. Observation only. Fires on every acquisition path - the Dragonshrine purchase (the essence is already spent when the emit runs), the debug CLI grant, and the ALL_UNLOCKS new-game grant-all loop - but never on save load, which restores the perk arrays directly. Toggling an owned perk on or off never fires either: the shrine menu and the debug CLI flip perks_active directly, without entering acquire_perk."
+
+[[hook]]
+name = "player.died"
+kind = "event"
+doc  = "Fires when the player actually dies: on should_die()'s final death path, after the screen fade completes and right after MIST.run_scene(\"dying\") starts the dying scene. ctx is the obj_ari instance. Observation only - ARI.end_of_day_status is already EndOfDayStatus.Died and the scene is under way when handlers run. A revive by the Fairy status effect never gets here, and neither does an averted death, which routes through pass_out() instead (see player.pass_out)."
 
 [[hook]]
 name = "player.equipment_bonus"
@@ -434,7 +439,7 @@ doc  = "Fires at the end of the player's move speed computation, after the statu
 [[hook]]
 name = "player.pass_out"
 kind = "event"
-doc  = "Fires in pass_out(), immediately after end_day()."
+doc  = "Fires in pass_out(), immediately after end_day() - the day rollover is already under way, stamina is zeroed, and the player is flagged invulnerable when handlers run. ctx is { faint }: true for the 2 AM collapse, false when the player went down to a killing blow but the death was averted (ARI.end_of_day_status tells the cases apart: Fainted for the plain collapse, Protected otherwise). Observation only. A normal bed sleep ends the day without pass_out(), and a death that is not averted runs the dying scene instead - see player.died."
 
 [[hook]]
 name = "player.renown_delta"
@@ -442,14 +447,9 @@ kind = "filter"
 doc  = "Fires at the top of Ari.modify_renown(), before the delta is applied. The filtered value is the renown delta. The engine's one gameplay caller is the on_new_day drain of pending_renown_entries, so this fires at day rollover, once per pending entry (quest completions, museum donations, the prior day's shipping gold). ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. set_renown clamps the resulting total to [0, max renown], so any replacement is safe: a negative delta lowers renown and the computed level, plays no celebration, and never revokes already-granted level rewards, while a gain that crosses several levels grants each crossed level's reward. The end-of-day menu tallies the raw pending entries before the drain, so its renown-earned figure shows unfiltered values. Absolute sets (debug, test suite, new game) do not route through modify_renown and never fire this hook."
 
 [[hook]]
-name = "player.should_die"
+name = "player.skill_leveled"
 kind = "event"
-doc  = "Fires after the cutscene for the player dying runs."
-
-[[hook]]
-name = "player.skill_xp_to_level"
-kind = "event"
-doc  = "Fires in skill_xp_to_level(), after the level has been calculated. ctx is { skill, level } - skill is the array position from Skill, while level is the skill level (the player's skills begin at level 2)"
+doc  = "Fires in gain_xp() when the applied XP raises the skill's level, right after the new total is written and before the level-up celebration. ctx is { skill, old_level, new_level, silent }: skill is the Skill enum id and silent is gain_xp's own flag, so silent engine gains (crafting XP, stable breeding) fire too, celebration or not. Gains only - a level lowered through a negative player.xp_delta replacement never fires. A single large gain can cross several levels and still fires once; compare old_level and new_level. Save load and the debug menu write skill_xp directly and never fire."
 
 [[hook]]
 name = "player.stamina_delta"
@@ -482,6 +482,21 @@ kind = "filter"
 doc  = "Fires at the top of Ari.gain_xp(skill, xp, silent), before the XP is applied. The filtered value is the XP delta; ctx is { player, skill, silent }, skill being the Skill.* enum id. Return the replacement delta, or undefined to keep the current value. A negative delta genuinely deducts XP and can lower the skill's level: the seam floors the filtered result at -skill_xp[skill] so the total never goes negative (levels 0 and 1 cost 0 XP, so the computed level bottoms out at 1, never the -1 a negative total would read as), and the seam narrows the level celebration to genuine gains, so a level DOWN does not play the LevelUp chime and dingaling (vanilla celebrates any level change; the narrowed condition is unreachable without a negative delta). The floor never binds on engine values (vanilla deltas are all non-negative). The engine's own cap at MAX_SKILL_LEVEL_COSTS still applies after the filter, and already-granted level rewards are not revoked by leveling down."
 
 [[hook]]
+name = "quest.complete"
+kind = "event"
+doc  = "Fires inside QuestLog.complete(quest_name), after the completion is validated (the quest is active and its final task is done) and before any completion bookkeeping - the T2R quest facts, the active-to-completed move, the request-board cleanup, the pending renown entry, and the achievements refresh all land after the emit. Calls that fail validation return early and never fire. ctx is { quest_name, quest }: quest is the ActiveQuest being completed (its prototype is quest.quest, its rewards quest.quest.reward_list). Observation only."
+
+[[hook]]
+name = "renown.level_gained"
+kind = "event"
+doc  = "Fires inside Ari.set_renown() when the write raises the renown level, past the gains-only early return and before the crossed levels' rewards are granted. ctx is { old_level, new_level }; a single write can cross several levels and still fires once. The engine's gameplay path here is the day-rollover drain of pending entries (each already filtered through player.renown_delta), and debug sets route through set_renown too; save load restores the renown field directly and never fires. Losses and level-neutral writes never fire - set_renown bails before the emit unless the level rose."
+
+[[hook]]
+name = "renown.rank_gained"
+kind = "event"
+doc  = "Fires inside Ari.set_renown() when a renown level gain crosses a rank boundary, immediately after renown.level_gained. ctx is { old_rank, new_rank }: integer indexes into RENOWN.ranks, clamped to the last rank (RENOWN.ranks.get(new_rank) is the rank struct). A gain within one rank fires renown.level_gained alone, and once the final rank is reached further level gains never fire this hook again."
+
+[[hook]]
 name = "resource.node_modifier"
 kind = "filter"
 doc  = "Fires at the top of pick_node() and chop_node(), before the tool's modifier is applied to a resource node (rocks, forage, dig sites, trees, stumps). The filtered value is the tool modifier: the charged-tool bonus/penalty added to item.damage and to the item.quality gate. ctx is { grid, x, y, item, action }; action is \"pick\" or \"chop\". Return the replacement modifier (for example clamp a negative charged-tool penalty to 0 to remove the charged-attack damage penalty), or undefined to keep the current value."
@@ -497,16 +512,6 @@ kind = "event"
 doc  = "Fires inside pick_node() when a pick LANDS: on a Rock right after damage is applied and the outcome is decided (before drops/teardown run), and on a successful dig-site dig. Furniture and rug picks, inadequate-quality bounces, and empty swings do not fire. ctx is { grid, x, y, item, node, result, destroyed, burn, effect_override }: result is \"rock\" or \"dig_site\", destroyed tells a chip from the break (for dig sites: whether the site is consumed), node for dig sites is read AFTER the dig so it may already reflect the dug/absent state, burn is the is_burn argument, and effect_override is non-undefined exactly for the engine's internal chained picks (the Earthbreaker perk), letting a handler skip picks no player swing caused. Fires for every caller of pick_node - Tool FSM, damage tarballs, and chains alike. The return value is ignored."
 
 [[hook]]
-name = "renown.to_level"
-kind = "event"
-doc  = "Fires at the end of renown_to_level(), after the level has been calculated. ctx is { level }."
-
-[[hook]]
-name = "renown.level_to_rank"
-kind = "event"
-doc  = "Fires at the end of renown_level_to_rank(), after the rank has been calculated. ctx is { rank }, with rank as an int."
-
-[[hook]]
 name = "request_board.fetch_pool"
 kind = "filter"
 doc  = "Fires in create_request_board()'s daily random top-up, after the crown offer and the always-available entries are already pushed and the candidate keys are shuffled, before the availability loop draws from them. The board builds once per day (new day, new game, and some loads), so this fires per build, not per viewing. The filtered value is the struct { random_pool, random_slots, year, season, day, is_crown_quest_day }: random_pool is the shuffled List of candidate request keys (a List with count()/get(), not an array), random_slots is the cap the draw stops at - it counts the WHOLE board, crown and always-available entries included, not just the random picks - year/season/day are the calendar date (day 1-based), and is_crown_quest_day reflects the crown cooldown being ready (an eligible offer may still be absent). ctx is undefined. Return the replacement struct, or undefined to keep the current values. The seam re-reads every field defensively, so a non-struct return or a partial struct keeps the engine values."
@@ -515,11 +520,6 @@ doc  = "Fires in create_request_board()'s daily random top-up, after the crown o
 name = "request_board.fetch_pool_ready"
 kind = "event"
 doc  = "Fires at the end of create_request_board(), after the final retain pass and the re-randomize, just before the built board list is returned. The board builds once per day (new day, new game, and some loads), so this fires per build, not per viewing. ctx is { year, season, day, is_crown_quest_day, final_pool }: the date fields match request_board.fetch_pool's, and final_pool is the LIVE List the function returns - pushing or removing entries here changes the actual board, so treat it as read-only unless that is the intent. The return value is ignored."
-
-[[hook]]
-name = "quest.complete"
-kind = "event"
-doc  = "Fires at the top of Questlog.complete(). ctx is { quest_name }."
 
 [[hook]]
 name = "save.game_loaded"
@@ -607,7 +607,7 @@ doc  = "Fires after a menu rebuilds its content from game state, at the tail of 
 [[hook]]
 name = "ui.spawn_tutorial_guard"
 kind = "guard"
-doc  = "Fires at the top of spawn_tutorial(tutorial), before the tutorial menu displays. Return false to suppress the tutorial from running; undefined or true allows."
+doc  = "Fires at the top of spawn_tutorial(tutorial), before the tutorial is marked seen and before its popup is built. ctx is { tutorial }, the Tutorial enum id. Return false to veto the popup (spawn_tutorial returns undefined, and the tutorial stays unmarked in ARI.tutorials_seen, so the game offers it again on its next trigger); undefined or true allows. The guard sits above the function's own test-suite early return, so it also fires - vacuously - in test-suite runs."
 
 [[hook]]
 name = "ui.sprite"
@@ -1885,9 +1885,16 @@ replace = '''
             MAX_SKILL_LEVEL_COSTS[skill],
         );
 
+        try {
+            var __mmapi_new_skill_level = ARI.level(skill);
+            if (old_skill_level < __mmapi_new_skill_level) {
+                mmapi_emit("player.skill_leveled", { skill: skill, old_level: old_skill_level, new_level: __mmapi_new_skill_level, silent: silent });
+            }
+        } catch (__mmapi_player_skill_leveled) {} // mmapi_player_run_skill_leveled
+
         if !silent && old_skill_level < ARI.level(skill) {'''
 marker  = "mmapi_player_run_xp_delta_filters"
-provides = ["player.xp_delta"]
+provides = ["player.xp_delta", "player.skill_leveled"]
 
 [[seam]]
 id      = "player_renown_delta"
@@ -2900,7 +2907,7 @@ provides = ["local.get", "local.missing"]
 id      = "ui_spawn_tutorial_guard"
 file    = "gml/scripts/UI/Anchor/anchor_utils.gml"
 target  = { fn = "spawn_tutorial", at = "head" }
-op    = "guard"
+op      = "guard"
 hook    = "ui.spawn_tutorial_guard"
 ctx     = "{ tutorial: tutorial }"
 on_veto = "return undefined;"
@@ -2909,47 +2916,21 @@ marker  = "mmapi_ui_spawn_tutorial_guard"
 [[seam]]
 id      = "player_acquire_perk"
 file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
-target  = { fn = "acquire_perk", at = "head"}
+target  = { fn = "acquire_perk", at = "head" }
 op      = "emit"
 hook    = "player.acquire_perk"
 ctx     = "{ perk: perk }"
+indent  = 8
 marker  = "mmapi_player_acquire_perk"
 
 [[seam]]
-id      = "player_skill_xp_to_level"
-file    = "gml/scripts/Xp.gml"
-target  = { fn = "skill_xp_to_level", at = "before", anchor = "return level - 1;" }
-op      = "emit"
-hook    = "player.skill_xp_to_level"
-ctx     = "{ skill: skill, level: level }"
-marker  = "mmapi_player_skill_xp_to_level"
-
-[[seam]]
-id      = "renown_level_to_rank"
-file    = "gml/scripts/GameplaySystems/Player/RenownUtils.gml"
-target  = { fn = "renown_level_to_rank", at = "before", anchor = "return RENOWN.ranks.get(rank);" }
-op      = "emit"
-hook    = "renown.level_to_rank"
-ctx     = "{ rank: rank }"
-marker  = "mmapi_renown_level_to_rank"
-
-[[seam]]
-id      = "renown_to_level"
-file    = "gml/scripts/GameplaySystems/Player/RenownUtils.gml"
-target  = { fn = "renown_to_level", at = "before", anchor = "return lo;" }
-op      = "emit"
-hook    = "renown.to_level"
-ctx     = "{ level: lo }"
-marker  = "mmapi_renown_to_level"
-
-[[seam]]
-id      = "donate_item_to_museum"
+id      = "museum_donate_item"
 file    = "gml/scripts/Museum.gml"
 target  = { fn = "donate_item_to_museum", at = "head" }
 op      = "emit"
 hook    = "museum.donate_item"
-ctx     = "{item_id: item_id}"
-marker  = "mmapi_donate_item_to_museum"
+ctx     = "{ item_id: item_id }"
+marker  = "mmapi_museum_donate_item"
 
 [[seam]]
 id      = "player_pass_out"
@@ -2957,23 +2938,59 @@ file    = "gml/scripts/Player/pass_out.gml"
 target  = { fn = "pass_out", at = "after", anchor = "end_day();" }
 op      = "emit"
 hook    = "player.pass_out"
-ctx     = "{faint: faint}"
+ctx     = "{ faint: faint }"
 marker  = "mmapi_player_pass_out"
 
 [[seam]]
-id      = "player_should_die"
+id      = "player_died"
 file    = "gml/objects/characters/obj_ari.gml"
 target  = { fn = "should_die", at = "after", anchor = '''MIST.run_scene("dying");''' }
 op      = "emit"
-hook    = "player.should_die"
+hook    = "player.died"
 ctx     = "self"
-marker  = "mmapi_player_should_die"
+indent  = 28
+marker  = "mmapi_player_died"
 
+# renown.level_gained and renown.rank_gained emit from one text seam inside
+# set_renown(), below its gains-only early return: only writes that raise the
+# level reach the emits, matching the hooks' names. A text seam because the
+# rank emit needs the boundary comparison, which the template ops cannot express.
+[[seam]]
+id      = "renown_gains"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+anchor  = '''
+        if sign(new_levels) != 1 {
+            return;
+        }
+
+        var rewards_len = RENOWN.rewards.count();'''
+replace = '''
+        if sign(new_levels) != 1 {
+            return;
+        }
+
+        try { mmapi_emit("renown.level_gained", { old_level: level, new_level: new_level }); } catch (__mmapi_renown_level_gained) {} // mmapi_renown_run_gains
+        try {
+            var __mmapi_old_rank = min(level div RENOWN.levels_per_rank, RENOWN.ranks.count() - 1);
+            var __mmapi_new_rank = min(new_level div RENOWN.levels_per_rank, RENOWN.ranks.count() - 1);
+            if (__mmapi_old_rank != __mmapi_new_rank) {
+                mmapi_emit("renown.rank_gained", { old_rank: __mmapi_old_rank, new_rank: __mmapi_new_rank });
+            }
+        } catch (__mmapi_renown_rank_gained) {}
+
+        var rewards_len = RENOWN.rewards.count();'''
+marker  = "mmapi_renown_run_gains"
+provides = ["renown.level_gained", "renown.rank_gained"]
+
+# quest.complete emits below QuestLog.complete()'s validation early-return (anchored
+# on the first T2R fact write) rather than at head, so a call for a quest that is not
+# active or not finished never fires. finished_quest is in scope and non-undefined there.
 [[seam]]
 id      = "quest_complete"
 file    = "gml/scripts/GameplaySystems/Quests/QuestLog.gml"
-target  = { fn = "complete", at = "head" }
+target  = { fn = "complete", at = "before", anchor = 'T2R.write(format("quest_{}_in_progress", quest_name), false);' }
 op      = "emit"
 hook    = "quest.complete"
-ctx     = "{ quest_name: quest_name }"
+ctx     = "{ quest_name: quest_name, quest: finished_quest }"
+indent  = 8
 marker  = "mmapi_quest_complete"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -36,8 +36,8 @@ version = 2
 # hook surface. Keep them in step when adding or removing entries; the
 # shipped-catalog test also holds the docs' count sentences to these numbers.
 [counts]
-hooks = 104
-seams = 114
+hooks = 113
+seams = 123
 engine_fixes = 3
 call_rewrites = 1
 
@@ -372,6 +372,16 @@ kind = "event"
 doc  = "Fires every frame for every monster in par_monster's begin step, right after the aggro update. ctx is the monster instance. Hot path. Keep handlers cheap."
 
 [[hook]]
+name = "museum.donate_item"
+kind = "event"
+doc = "Fires at the top of donate_item_to_museum(), before the item is registered to the museum. ctx is { item_id }." 
+
+[[hook]]
+name = "player.acquire_perk"
+kind = "event"
+doc  = "Fires at the top of acquire_perk(). ctx is perk, as the perk id"
+
+[[hook]]
 name = "player.equipment_bonus"
 kind = "filter"
 doc  = "Fires at the return of the player's equipment bonus lookup. The filtered value is the computed bonus. ctx is { player, infusion, key }. Return the replacement value, or undefined to keep the current value."
@@ -422,9 +432,24 @@ kind = "filter"
 doc  = "Fires at the end of the player's move speed computation, after the status effect multipliers. The filtered value is the speed. ctx is { player, on_mount }. Return the replacement speed, or undefined to keep the current value. Mounted movement routes through this computation too (ctx.on_mount is true); the mounted base speed is separately filterable earlier in the computation via player.mount_speed. Swimming does not route through here - that is player.swim_speed."
 
 [[hook]]
+name = "player.pass_out"
+kind = "event"
+doc  = "Fires in pass_out(), immediately after end_day()."
+
+[[hook]]
 name = "player.renown_delta"
 kind = "filter"
 doc  = "Fires at the top of Ari.modify_renown(), before the delta is applied. The filtered value is the renown delta. The engine's one gameplay caller is the on_new_day drain of pending_renown_entries, so this fires at day rollover, once per pending entry (quest completions, museum donations, the prior day's shipping gold). ctx is { player }. Return the replacement delta (0 makes the call a no-op), or undefined to keep the current value. set_renown clamps the resulting total to [0, max renown], so any replacement is safe: a negative delta lowers renown and the computed level, plays no celebration, and never revokes already-granted level rewards, while a gain that crosses several levels grants each crossed level's reward. The end-of-day menu tallies the raw pending entries before the drain, so its renown-earned figure shows unfiltered values. Absolute sets (debug, test suite, new game) do not route through modify_renown and never fire this hook."
+
+[[hook]]
+name = "player.should_die"
+kind = "event"
+doc  = "Fires after the cutscene for the player dying runs."
+
+[[hook]]
+name = "player.skill_xp_to_level"
+kind = "event"
+doc  = "Fires in skill_xp_to_level(), after the level has been calculated. ctx is { skill, level } - skill is the array position from Skill, while level is the skill level (the player's skills begin at level 2)"
 
 [[hook]]
 name = "player.stamina_delta"
@@ -472,6 +497,16 @@ kind = "event"
 doc  = "Fires inside pick_node() when a pick LANDS: on a Rock right after damage is applied and the outcome is decided (before drops/teardown run), and on a successful dig-site dig. Furniture and rug picks, inadequate-quality bounces, and empty swings do not fire. ctx is { grid, x, y, item, node, result, destroyed, burn, effect_override }: result is \"rock\" or \"dig_site\", destroyed tells a chip from the break (for dig sites: whether the site is consumed), node for dig sites is read AFTER the dig so it may already reflect the dug/absent state, burn is the is_burn argument, and effect_override is non-undefined exactly for the engine's internal chained picks (the Earthbreaker perk), letting a handler skip picks no player swing caused. Fires for every caller of pick_node - Tool FSM, damage tarballs, and chains alike. The return value is ignored."
 
 [[hook]]
+name = "renown.to_level"
+kind = "event"
+doc  = "Fires at the end of renown_to_level(), after the level has been calculated. ctx is { level }."
+
+[[hook]]
+name = "renown.level_to_rank"
+kind = "event"
+doc  = "Fires at the end of renown_level_to_rank(), after the rank has been calculated. ctx is { rank }, with rank as an int."
+
+[[hook]]
 name = "request_board.fetch_pool"
 kind = "filter"
 doc  = "Fires in create_request_board()'s daily random top-up, after the crown offer and the always-available entries are already pushed and the candidate keys are shuffled, before the availability loop draws from them. The board builds once per day (new day, new game, and some loads), so this fires per build, not per viewing. The filtered value is the struct { random_pool, random_slots, year, season, day, is_crown_quest_day }: random_pool is the shuffled List of candidate request keys (a List with count()/get(), not an array), random_slots is the cap the draw stops at - it counts the WHOLE board, crown and always-available entries included, not just the random picks - year/season/day are the calendar date (day 1-based), and is_crown_quest_day reflects the crown cooldown being ready (an eligible offer may still be absent). ctx is undefined. Return the replacement struct, or undefined to keep the current values. The seam re-reads every field defensively, so a non-struct return or a partial struct keeps the engine values."
@@ -480,6 +515,11 @@ doc  = "Fires in create_request_board()'s daily random top-up, after the crown o
 name = "request_board.fetch_pool_ready"
 kind = "event"
 doc  = "Fires at the end of create_request_board(), after the final retain pass and the re-randomize, just before the built board list is returned. The board builds once per day (new day, new game, and some loads), so this fires per build, not per viewing. ctx is { year, season, day, is_crown_quest_day, final_pool }: the date fields match request_board.fetch_pool's, and final_pool is the LIVE List the function returns - pushing or removing entries here changes the actual board, so treat it as read-only unless that is the intent. The return value is ignored."
+
+[[hook]]
+name = "quest.complete"
+kind = "event"
+doc  = "Fires at the top of Questlog.complete(). ctx is { quest_name }."
 
 [[hook]]
 name = "save.game_loaded"
@@ -563,6 +603,11 @@ doc  = "Fires in StoreMenu right after a shelf tap adds an item to the shopping 
 name = "ui.menu_refreshed"
 kind = "event"
 doc  = "Fires after a menu rebuilds its content from game state, at the tail of the rebuild function. Emitting menus today: ToolbarMenu.update() (slot items re-resolved from the inventory: subscriber pull, page flips, tab taps, forced rebuilds, constructor) and VitalsMenu.refresh_statuses() (status icon strip rebuilt: register, cancel, and the expiry poll). ctx is { menu, kind }, with kind read from menu.type. Emits only on rebuild edges, never per idle frame, including during the menu's constructor before ui.menu_opened fires for it (ctx.menu is not yet in ANCHOR.open_menus then). Handlers must be idempotent and must not unconditionally force another rebuild from inside the handler."
+
+[[hook]]
+name = "ui.spawn_tutorial_guard"
+kind = "guard"
+doc  = "Fires at the top of spawn_tutorial(tutorial), before the tutorial menu displays. Return false to suppress the tutorial from running; undefined or true allows."
 
 [[hook]]
 name = "ui.sprite"
@@ -2850,3 +2895,85 @@ callee   = "local_get"
 to       = "mmapi_local_get"
 args     = 1
 provides = ["local.get", "local.missing"]
+
+[[seam]]
+id      = "ui_spawn_tutorial_guard"
+file    = "gml/scripts/UI/Anchor/anchor_utils.gml"
+target  = { fn = "spawn_tutorial", at = "head" }
+op    = "guard"
+hook    = "ui.spawn_tutorial_guard"
+ctx     = "{ tutorial: tutorial }"
+on_veto = "return undefined;"
+marker  = "mmapi_ui_spawn_tutorial_guard"
+
+[[seam]]
+id      = "player_acquire_perk"
+file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
+target  = { fn = "acquire_perk", at = "head"}
+op      = "emit"
+hook    = "player.acquire_perk"
+ctx     = "{ perk: perk }"
+marker  = "mmapi_player_acquire_perk"
+
+[[seam]]
+id      = "player_skill_xp_to_level"
+file    = "gml/scripts/Xp.gml"
+target  = { fn = "skill_xp_to_level", at = "before", anchor = "return level - 1;" }
+op      = "emit"
+hook    = "player.skill_xp_to_level"
+ctx     = "{ skill: skill, level: level }"
+marker  = "mmapi_player_skill_xp_to_level"
+
+[[seam]]
+id      = "renown_level_to_rank"
+file    = "gml/scripts/GameplaySystems/Player/RenownUtils.gml"
+target  = { fn = "renown_level_to_rank", at = "before", anchor = "return RENOWN.ranks.get(rank);" }
+op      = "emit"
+hook    = "renown.level_to_rank"
+ctx     = "{ rank: rank }"
+marker  = "mmapi_renown_level_to_rank"
+
+[[seam]]
+id      = "renown_to_level"
+file    = "gml/scripts/GameplaySystems/Player/RenownUtils.gml"
+target  = { fn = "renown_to_level", at = "before", anchor = "return lo;" }
+op      = "emit"
+hook    = "renown.to_level"
+ctx     = "{ level: lo }"
+marker  = "mmapi_renown_to_level"
+
+[[seam]]
+id      = "donate_item_to_museum"
+file    = "gml/scripts/Museum.gml"
+target  = { fn = "donate_item_to_museum", at = "head" }
+op      = "emit"
+hook    = "museum.donate_item"
+ctx     = "{item_id: item_id}"
+marker  = "mmapi_donate_item_to_museum"
+
+[[seam]]
+id      = "player_pass_out"
+file    = "gml/scripts/Player/pass_out.gml"
+target  = { fn = "pass_out", at = "after", anchor = "end_day();" }
+op      = "emit"
+hook    = "player.pass_out"
+ctx     = "{faint: faint}"
+marker  = "mmapi_player_pass_out"
+
+[[seam]]
+id      = "player_should_die"
+file    = "gml/objects/characters/obj_ari.gml"
+target  = { fn = "should_die", at = "after", anchor = '''MIST.run_scene("dying");''' }
+op      = "emit"
+hook    = "player.should_die"
+ctx     = "self"
+marker  = "mmapi_player_should_die"
+
+[[seam]]
+id      = "quest_complete"
+file    = "gml/scripts/GameplaySystems/Quests/QuestLog.gml"
+target  = { fn = "complete", at = "head" }
+op      = "emit"
+hook    = "quest.complete"
+ctx     = "{ quest_name: quest_name }"
+marker  = "mmapi_quest_complete"

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **113 hooks**, fed by **123 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **113 hooks**, fed by **121 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -72,9 +72,11 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [player.max_health_item](hooks/player.max_health_item.md) | event | Know when an item permanently raises Ari's max health. |
 | [player.heal_vfx](hooks/player.heal_vfx.md) | guard | Block the player's heal sparkle before it plays. |
 | [player.pass_out](hooks/player.pass_out.md) | event | Know when the player passes out at the end of the day. |
-| [player.should_die](hooks/player.should_die.md) | event | Know when the player dies. |
-| [player.skill_xp_to_level](hooks/player.skill_xp_to_level.md) | event | Know when the player levels up one of their skills. |
+| [player.died](hooks/player.died.md) | event | Know when the player dies. |
 | [player.acquire_perk](hooks/player.acquire_perk.md) | event | Know when the player acquires a perk. |
+| [player.skill_leveled](hooks/player.skill_leveled.md) | event | Know the moment the player levels up a skill. |
+| [renown.level_gained](hooks/renown.level_gained.md) | event | Know the moment the player gains a renown level. |
+| [renown.rank_gained](hooks/renown.rank_gained.md) | event | Know the moment the player reaches a new renown rank. |
 | [player.status_effect_register](hooks/player.status_effect_register.md) | filter | Rewrite a status effect as it registers. |
 | [player.status_effect_cancel](hooks/player.status_effect_cancel.md) | event | Know when the game cancels a status effect. |
 | [player.status_effect_expired](hooks/player.status_effect_expired.md) | event | Know the moment a status effect runs out. |
@@ -132,7 +134,7 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [ui.item_icon](hooks/ui.item_icon.md) | filter | Swap the sprite an item shows as its icon. |
 | [ui.item_node](hooks/ui.item_node.md) | filter | Adjust UI item slots as they are populated. |
 | [ui.button_sprites](hooks/ui.button_sprites.md) | filter | Swap the sprite set a UI button is built from. |
-| [ui.spawn_tutorial_guard](hooks/ui.spawn_tutorial_guard.md) | guard | Block when a tutorial sequence plays. |
+| [ui.spawn_tutorial_guard](hooks/ui.spawn_tutorial_guard.md) | guard | Block a tutorial popup before it spawns. |
 | [ui.sprite](hooks/ui.sprite.md) | filter | Swap the backplate sprites behind the mines menu and spell cards. |
 | [dialogue.play_guard](hooks/dialogue.play_guard.md) | guard | Block a conversation before it starts. |
 | [dialogue.path](hooks/dialogue.path.md) | filter | Change which conversation plays before it starts. |
@@ -145,8 +147,6 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [local.missing](hooks/local.missing.md) | filter | Change what a missing localization key resolves to. |
 | [input.check_value_id](hooks/input.check_value_id.md) | filter | Swap the input id `Input.check_value()` looks up. |
 | [input.take_press](hooks/input.take_press.md) | guard | Block an interactable's press before the interaction runs. |
-| [renown.to_level](hooks/renown.to_level.md) | event | Know when the game converts the player's renown to its level. |
-| [renown.level_to_rank](hooks/renown.level_to_rank.md) | event | Know when the game converts the player's renown level to rank. |
 
 ## Seams
 
@@ -181,13 +181,13 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [pick_node_picked_dig_site](seams/pick_node_picked_dig_site.md) | Emits the moment a dig site is successfully dug. |
 | [request_board_fetch_pool](seams/request_board_fetch_pool.md) | Rewrites the request board's daily random top-up so the candidate pool and draw cap pass through a filter. |
 | [request_board_fetch_pool_ready](seams/request_board_fetch_pool_ready.md) | Emits the finished request board at the tail of the daily build, final pool included. |
-| [quest_complete](seams/quest_complete.md) | Emits at the head of `QuestLog.complete()`. |
+| [quest_complete](seams/quest_complete.md) | Emits inside `QuestLog.complete()` once the completion is validated, before the bookkeeping runs. |
 | [furniture_place_guard](seams/furniture_place_guard.md) | Puts a veto check in front of every furniture placement. |
 | [furniture_floor_sprite](seams/furniture_floor_sprite.md) | Filters the floor sprite as a furniture renderer is built. |
 | [object_interact](seams/object_interact.md) | Puts a claim-scoped override in front of every grid-object interaction. |
 | [node_renderer_set_sprite](seams/node_renderer_set_sprite.md) | Filters the sprite every world node renderer is about to wear. |
 | [store_item_added](seams/store_item_added.md) | Announces every shelf tap that puts an item in the shopping basket. |
-| [donate_item_to_museum](seams/donate_item_to_museum.md) | Emits the moment an item is donated to the museum. |
+| [museum_donate_item](seams/museum_donate_item.md) | Emits the moment an item is donated to the museum. |
 
 ### Player, Actors, And Progression
 
@@ -199,7 +199,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_gold_delta](seams/player_gold_delta.md) | Filters the signed gold delta at the top of `Ari.modify_gold()`. |
 | [player_mana_delta](seams/player_mana_delta.md) | Filters the signed mana delta at the top of `Ari.modify_mana()`. |
 | [player_mana_item_delta](seams/player_mana_item_delta.md) | Reroutes the mana potion's direct `set_mana` call through `modify_mana`, so item restores fire the mana filter. |
-| [player_xp_delta](seams/player_xp_delta.md) | Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and narrows the level celebration to genuine gains. |
+| [player_xp_delta](seams/player_xp_delta.md) | Filters the XP delta at the head of `gain_xp()`, floors the total at zero, narrows the level celebration to genuine gains, and emits the skill level-up. |
 | [player_renown_delta](seams/player_renown_delta.md) | Filters the renown delta at the top of `Ari.modify_renown()`, once per pending entry at day rollover. |
 | [player_incoming_damage](seams/player_incoming_damage.md) | Rewrites the player's damage drain so mods filter the final damage and its popup and flinch side effects. |
 | [player_move_speed](seams/player_move_speed.md) | Filters the player's computed move speed after the status-effect multipliers. |
@@ -208,10 +208,10 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_equipment_bonus](seams/player_equipment_bonus.md) | Rewrites the equipment bonus lookup's return into a filtered return. |
 | [player_max_health_item](seams/player_max_health_item.md) | Emits right after an item raises the player's base health. |
 | [player_heal_vfx](seams/player_heal_vfx.md) | Puts a veto check at the head of `play_heal_vfx()`. |
-| [player_pass_out](seam/player_pass_out.md) | Emits right after the player passes out. |
-| [player_should_die](seams/player_should_die.md) | Emits right after the game runs the death cutscene. |
-| [player_skill_xp_to_level](seams/player_skill_xp_to_level.md) | Emits after the game calculates the new skill level. |
+| [player_pass_out](seams/player_pass_out.md) | Emits inside `pass_out()`, right after `end_day()`. |
+| [player_died](seams/player_died.md) | Emits on the final death path, right after the dying scene starts. |
 | [player_acquire_perk](seams/player_acquire_perk.md) | Emits at the head of `acquire_perk()`. |
+| [renown_gains](seams/renown_gains.md) | Emits renown level and rank gains inside `set_renown()`, past its gains-only early return. |
 | [player_status_effect_register](seams/player_status_effect_register.md) | Filters every status effect's fields at the top of `register()`. |
 | [player_status_effect_cancel](seams/player_status_effect_cancel.md) | Emits at the head of `StatusEffectManager.cancel()`, before any lookup. |
 | [player_status_effect_expired](seams/player_status_effect_expired.md) | Emits inside `update()`'s expiry branch, right after the effect is removed. |
@@ -279,7 +279,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [ui_item_node_set_to_item](seams/ui_item_node_set_to_item.md) | Hands every populated UI item node to mods, right after its icon is set. |
 | [ui_item_node_crafting_menu](seams/ui_item_node_crafting_menu.md) | Hands each crafting-grid icon node to mods as the menu builds. |
 | [ui_button_sprites](seams/ui_button_sprites.md) | Puts a filter on each built button sprite set before it enters the cache. |
-| [ui_spawn_tutorial_guard](seams/ui_spawn_tutorial_guard) | Puts a veto check at the head of a tutorial playing.  |
+| [ui_spawn_tutorial_guard](seams/ui_spawn_tutorial_guard.md) | Puts a veto check at the head of `spawn_tutorial()`. |
 | [ui_sprite_mines_backplate](seams/ui_sprite_mines_backplate.md) | Routes the mines menu backplate sprite through a filter on dungeon room start. |
 | [ui_sprite_spell_card_backplate](seams/ui_sprite_spell_card_backplate.md) | Routes each spell card's backplate sprite through a filter. |
 | [dialogue_play_guard](seams/dialogue_play_guard.md) | Puts a veto check at the head of `play_conversation()`. |

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **104 hooks**, fed by **114 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **113 hooks**, fed by **123 seams**, **3 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -45,11 +45,13 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [resource.node_picked](hooks/resource.node_picked.md) | event | Know the moment a pick lands on a rock or dig site. |
 | [request_board.fetch_pool](hooks/request_board.fetch_pool.md) | filter | Change the request board's daily candidate pool and draw cap. |
 | [request_board.fetch_pool_ready](hooks/request_board.fetch_pool_ready.md) | event | Know the finished request board the moment it is built each day. |
+| [quest.complete](hooks/quest.complete.md) | event | Know when a quest is completed. |
 | [furniture.place_guard](hooks/furniture.place_guard.md) | guard | Veto a furniture placement before it is written. |
 | [furniture.floor_sprite](hooks/furniture.floor_sprite.md) | filter | Swap a furniture piece's floor sprite as its renderer is built. |
 | [object.interact](hooks/object.interact.md) | override | Take over any grid object's interaction. |
 | [object.node_sprite](hooks/object.node_sprite.md) | filter | Swap the sprite of any world node before it draws. |
 | [store.item_added](hooks/store.item_added.md) | event | Know when an item lands in the shopping basket. |
+| [museum.donate_item](hooks/museum.donate_item.md) | event | Know when an item is donated to the museum. |
 
 ### Player, Actors, And Progression
 
@@ -69,6 +71,10 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [player.equipment_bonus](hooks/player.equipment_bonus.md) | filter | Adjust the bonus an equipment infusion grants the player. |
 | [player.max_health_item](hooks/player.max_health_item.md) | event | Know when an item permanently raises Ari's max health. |
 | [player.heal_vfx](hooks/player.heal_vfx.md) | guard | Block the player's heal sparkle before it plays. |
+| [player.pass_out](hooks/player.pass_out.md) | event | Know when the player passes out at the end of the day. |
+| [player.should_die](hooks/player.should_die.md) | event | Know when the player dies. |
+| [player.skill_xp_to_level](hooks/player.skill_xp_to_level.md) | event | Know when the player levels up one of their skills. |
+| [player.acquire_perk](hooks/player.acquire_perk.md) | event | Know when the player acquires a perk. |
 | [player.status_effect_register](hooks/player.status_effect_register.md) | filter | Rewrite a status effect as it registers. |
 | [player.status_effect_cancel](hooks/player.status_effect_cancel.md) | event | Know when the game cancels a status effect. |
 | [player.status_effect_expired](hooks/player.status_effect_expired.md) | event | Know the moment a status effect runs out. |
@@ -126,6 +132,7 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [ui.item_icon](hooks/ui.item_icon.md) | filter | Swap the sprite an item shows as its icon. |
 | [ui.item_node](hooks/ui.item_node.md) | filter | Adjust UI item slots as they are populated. |
 | [ui.button_sprites](hooks/ui.button_sprites.md) | filter | Swap the sprite set a UI button is built from. |
+| [ui.spawn_tutorial_guard](hooks/ui.spawn_tutorial_guard.md) | guard | Block when a tutorial sequence plays. |
 | [ui.sprite](hooks/ui.sprite.md) | filter | Swap the backplate sprites behind the mines menu and spell cards. |
 | [dialogue.play_guard](hooks/dialogue.play_guard.md) | guard | Block a conversation before it starts. |
 | [dialogue.path](hooks/dialogue.path.md) | filter | Change which conversation plays before it starts. |
@@ -138,6 +145,8 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [local.missing](hooks/local.missing.md) | filter | Change what a missing localization key resolves to. |
 | [input.check_value_id](hooks/input.check_value_id.md) | filter | Swap the input id `Input.check_value()` looks up. |
 | [input.take_press](hooks/input.take_press.md) | guard | Block an interactable's press before the interaction runs. |
+| [renown.to_level](hooks/renown.to_level.md) | event | Know when the game converts the player's renown to its level. |
+| [renown.level_to_rank](hooks/renown.level_to_rank.md) | event | Know when the game converts the player's renown level to rank. |
 
 ## Seams
 
@@ -172,11 +181,13 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [pick_node_picked_dig_site](seams/pick_node_picked_dig_site.md) | Emits the moment a dig site is successfully dug. |
 | [request_board_fetch_pool](seams/request_board_fetch_pool.md) | Rewrites the request board's daily random top-up so the candidate pool and draw cap pass through a filter. |
 | [request_board_fetch_pool_ready](seams/request_board_fetch_pool_ready.md) | Emits the finished request board at the tail of the daily build, final pool included. |
+| [quest_complete](seams/quest_complete.md) | Emits at the head of `QuestLog.complete()`. |
 | [furniture_place_guard](seams/furniture_place_guard.md) | Puts a veto check in front of every furniture placement. |
 | [furniture_floor_sprite](seams/furniture_floor_sprite.md) | Filters the floor sprite as a furniture renderer is built. |
 | [object_interact](seams/object_interact.md) | Puts a claim-scoped override in front of every grid-object interaction. |
 | [node_renderer_set_sprite](seams/node_renderer_set_sprite.md) | Filters the sprite every world node renderer is about to wear. |
 | [store_item_added](seams/store_item_added.md) | Announces every shelf tap that puts an item in the shopping basket. |
+| [donate_item_to_museum](seams/donate_item_to_museum.md) | Emits the moment an item is donated to the museum. |
 
 ### Player, Actors, And Progression
 
@@ -197,6 +208,10 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_equipment_bonus](seams/player_equipment_bonus.md) | Rewrites the equipment bonus lookup's return into a filtered return. |
 | [player_max_health_item](seams/player_max_health_item.md) | Emits right after an item raises the player's base health. |
 | [player_heal_vfx](seams/player_heal_vfx.md) | Puts a veto check at the head of `play_heal_vfx()`. |
+| [player_pass_out](seam/player_pass_out.md) | Emits right after the player passes out. |
+| [player_should_die](seams/player_should_die.md) | Emits right after the game runs the death cutscene. |
+| [player_skill_xp_to_level](seams/player_skill_xp_to_level.md) | Emits after the game calculates the new skill level. |
+| [player_acquire_perk](seams/player_acquire_perk.md) | Emits at the head of `acquire_perk()`. |
 | [player_status_effect_register](seams/player_status_effect_register.md) | Filters every status effect's fields at the top of `register()`. |
 | [player_status_effect_cancel](seams/player_status_effect_cancel.md) | Emits at the head of `StatusEffectManager.cancel()`, before any lookup. |
 | [player_status_effect_expired](seams/player_status_effect_expired.md) | Emits inside `update()`'s expiry branch, right after the effect is removed. |
@@ -264,6 +279,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [ui_item_node_set_to_item](seams/ui_item_node_set_to_item.md) | Hands every populated UI item node to mods, right after its icon is set. |
 | [ui_item_node_crafting_menu](seams/ui_item_node_crafting_menu.md) | Hands each crafting-grid icon node to mods as the menu builds. |
 | [ui_button_sprites](seams/ui_button_sprites.md) | Puts a filter on each built button sprite set before it enters the cache. |
+| [ui_spawn_tutorial_guard](seams/ui_spawn_tutorial_guard) | Puts a veto check at the head of a tutorial playing.  |
 | [ui_sprite_mines_backplate](seams/ui_sprite_mines_backplate.md) | Routes the mines menu backplate sprite through a filter on dungeon room start. |
 | [ui_sprite_spell_card_backplate](seams/ui_sprite_spell_card_backplate.md) | Routes each spell card's backplate sprite through a filter. |
 | [dialogue_play_guard](seams/dialogue_play_guard.md) | Puts a veto check at the head of `play_conversation()`. |

--- a/docs/MMAPI/HOOKS.md
+++ b/docs/MMAPI/HOOKS.md
@@ -11,7 +11,7 @@ Most shipped hooks are dispatched from engine seams. A few are emitted directly 
 > [!NOTE]
 > A mod uses the game hooks MOMI already ships. It never packages its own seams. Mods can also publish custom hooks as cross-mod extension points, covered in [Publishing Custom Hooks](#publishing-custom-hooks).
 
-The shipped catalog currently declares **104 hooks**, fed by **114 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **113 hooks**, fed by **121 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 ## Using A Shipped Hook
 

--- a/docs/MMAPI/SEAMS.md
+++ b/docs/MMAPI/SEAMS.md
@@ -20,7 +20,7 @@ The catalog is `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`, embedded int
 
 The catalog opens with a `[counts]` integrity table declaring those totals; the loader refuses a catalog whose parsed stanzas disagree, so a truncated or mis-merged file fails at load. The shipped-catalog test also holds the count sentences on this page, the [Catalog](CATALOG.md), and [Hooks](HOOKS.md) to the same numbers.
 
-The shipped catalog currently declares **104 hooks**, fed by **114 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
+The shipped catalog currently declares **113 hooks**, fed by **121 seams**, **3 engine fixes**, and **1 call rewrite**. The [Catalog](CATALOG.md) gives each one its own page.
 
 Some hooks use `provider = "runtime"`. The framework emits those itself, with no engine edit behind them. `combat.damage_injected`, `game.day_changed`, and `game.room_changed` are the current runtime-provided hooks. The derived ones are polls over live state (`room()`, `total_days()`): they lag the change they report, and the first poll of a session only records the baseline, so no event fires for the state a session starts in. Treat them as edge triggers: react to the change, but read the live state at any later decision point rather than caching their ctx (see the warning on [game.room_changed](hooks/game.room_changed.md)). For the day boundary specifically, the in-engine [game.new_day](hooks/game.new_day.md) fires from `new_day()` itself, before the end-of-day autosave and never on a load. The derived `game.day_changed` lags both.
 

--- a/docs/MMAPI/hooks/dialogue.play_guard.md
+++ b/docs/MMAPI/hooks/dialogue.play_guard.md
@@ -51,3 +51,4 @@ mmapi_guard("dialogue.play_guard", quiet_town_dialogue_play_guard);
 - [dialogue.path](dialogue.path.md) - Change which conversation plays. It has the same struct shape and runs after the guard allows.
 - [dialogue.line](dialogue.line.md) - Reword any dialogue line before the textbox shows it.
 - [dialogue.npc_blip](dialogue.npc_blip.md) - Swap the blip sound an NPC speaks with.
+- [ui.spawn_tutorial_guard](ui.spawn_tutorial_guard.md) - Block a tutorial popup before it spawns.

--- a/docs/MMAPI/hooks/game.new_day.md
+++ b/docs/MMAPI/hooks/game.new_day.md
@@ -49,3 +49,4 @@ mmapi_on("game.new_day", daily_reset_game_new_day);
 - [game.day_changed](game.day_changed.md) - This is the poll-side observation of the day changing: it fires one frame later (after the end-of-day autosave), also fires after a cross-day save load, and never fires for the day a session starts in. Prefer `game.new_day` for daily resets and grants.
 - [save.game_saving](save.game_saving.md) - This fires next on the end-of-day path, when the autosave commits.
 - [game.clock_tick](game.clock_tick.md) - This is the every-frame clock event, for when a day is too coarse.
+- [player.pass_out](player.pass_out.md) - This event fires inside `pass_out()`, right after the `end_day()` call that starts this rollover.

--- a/docs/MMAPI/hooks/museum.donate_item.md
+++ b/docs/MMAPI/hooks/museum.donate_item.md
@@ -1,0 +1,48 @@
+# Hook: museum.donate_item
+
+Know when an item is donated to the museum.
+
+`museum.donate_item` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `donate_item_to_museum()`, before the item is registered to the collection and before the pending renown entry is pushed. ctx is `{ item_id }`.
+
+This hook is observation only. The `DonationResult` the function goes on to compute (progress made, completed set, rewards) is decided after the emit, so a handler sees the donation before the museum knows what it amounts to. It fires once per donated item, from the museum donation menu (and the engine's test suite). Save load and the `ALL_UNLOCKS` new-game path write donations through `register_item_to_museum()` directly and never fire this hook, so handlers see genuine player donations only.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `donate_item_to_museum()`, before the item is registered or the renown entry is pushed. |
+| **ctx** | `{ item_id }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `item_id` - the `ItemId` being donated.
+
+## Usage
+
+```gml
+// museum.donate_item is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function curator_ledger_museum_donate_item(_ctx) {
+    // _ctx is { item_id }.
+    //   .item_id - the ItemId being donated.
+    // The donation has not been written yet: MUSEUM_PROGRESS[_ctx.item_id]
+    // still reads false here, and flips right after the emit.
+    // if (_ctx.item_id == <your tracked item>) { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("museum.donate_item", curator_ledger_museum_donate_item);
+```
+
+## Engine Wiring
+
+- Seam [`museum_donate_item`](../seams/museum_donate_item.md) dispatches from `gml/scripts/Museum.gml`, at the head of `donate_item_to_museum()`.
+
+## See Also
+
+- [player.renown_delta](player.renown_delta.md) - This filter is where the donation's renown lands at day rollover, one pending entry per donation.
+- [quest.complete](quest.complete.md) - This event is the other progression moment that queues a pending renown entry.
+- [store.item_added](store.item_added.md) - Know when an item lands in the shopping basket.

--- a/docs/MMAPI/hooks/player.acquire_perk.md
+++ b/docs/MMAPI/hooks/player.acquire_perk.md
@@ -1,0 +1,48 @@
+# Hook: player.acquire_perk
+
+Know when the player acquires a perk.
+
+`player.acquire_perk` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `Ari.acquire_perk(perk)`, before the perk is flagged owned and active and before its acquisition side effects (the Guardian's Shield extra invulnerable hit, the Ancient Inspiration timer reset) run. ctx is `{ perk }`, the `Perk` enum id.
+
+This hook is observation only. It fires on every acquisition path: the Dragonshrine purchase (the essence is already spent when the emit runs), the debug CLI grant, and the `ALL_UNLOCKS` new-game grant-all loop. It never fires on save load, which restores the perk arrays directly. Toggling an owned perk on or off never fires either. The shrine menu and the debug CLI flip `perks_active` directly, without entering `acquire_perk()`. At emit time `ARI.perks[ctx.perk]` still reads its old value, so a handler can tell a fresh acquisition from a re-grant.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `Ari.acquire_perk(perk)`, before the perk flags are written. |
+| **ctx** | `{ perk }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `perk` - the `Perk` enum id being acquired. `perk_to_string(perk)` names it.
+
+## Usage
+
+```gml
+// player.acquire_perk is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function perk_fanfare_player_acquire_perk(_ctx) {
+    // _ctx is { perk }.
+    //   .perk - the Perk enum id being acquired.
+    // ARI.perks[_ctx.perk] is not written yet, so a false read here
+    // means a genuinely new perk (the ALL_UNLOCKS loop re-grants freely).
+    // if (!ARI.perks[_ctx.perk]) { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("player.acquire_perk", perk_fanfare_player_acquire_perk);
+```
+
+## Engine Wiring
+
+- Seam [`player_acquire_perk`](../seams/player_acquire_perk.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `acquire_perk()`.
+
+## See Also
+
+- [player.essence_delta](player.essence_delta.md) - The Dragonshrine purchase's essence cost routes through this filter, right before the perk is acquired.
+- [player.max_health_item](player.max_health_item.md) - Know when an item permanently raises Ari's max health.
+- [player.skill_leveled](player.skill_leveled.md) - Know the moment the player levels up a skill.

--- a/docs/MMAPI/hooks/player.died.md
+++ b/docs/MMAPI/hooks/player.died.md
@@ -1,0 +1,47 @@
+# Hook: player.died
+
+Know when the player dies.
+
+`player.died` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires when the player actually dies, on `should_die()`'s final death path, after the screen fade completes and right after `MIST.run_scene("dying")` starts the dying scene. ctx is the `obj_ari` instance.
+
+This hook is observation only. `ARI.end_of_day_status` is already `EndOfDayStatus.Died` and the scene is under way when handlers run, so handler work should be read-and-react. A revive by the Fairy status effect never gets here (health and stamina are restored and play continues). Neither does an averted death, which routes through `pass_out()` instead. See [player.pass_out](player.pass_out.md).
+
+| | |
+| --- | --- |
+| **Fires** | On the final death path of `should_die()`, right after the dying scene starts. |
+| **ctx** | The `obj_ari` player instance. |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx parameter
+
+- The `obj_ari` player instance. The death is committed, the deaths stat is counted, `ARI.end_of_day_status` is `EndOfDayStatus.Died`, the death animation has held, and the screen has faded out.
+
+## Usage
+
+```gml
+// player.died is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function memento_mori_player_died(_ctx) {
+    // _ctx is the obj_ari instance.
+    // The dying scene has just started and the screen is faded out.
+    // React (record, tally, adjust your mod's own state). Do not fight
+    // the scene from here.
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("player.died", memento_mori_player_died);
+```
+
+## Engine Wiring
+
+- Seam [`player_died`](../seams/player_died.md) dispatches from `gml/objects/characters/obj_ari.gml`, inside `should_die()`'s screen-fade callback, immediately after `MIST.run_scene("dying");`.
+
+## See Also
+
+- [player.pass_out](player.pass_out.md) - This event covers the 2 AM collapse and the averted death, which skip the dying scene.
+- [player.incoming_damage](player.incoming_damage.md) - Change the final damage a hit deals the player, before it can kill.
+- [player.health_delta](player.health_delta.md) - Change every player health gain or loss before it applies.

--- a/docs/MMAPI/hooks/player.health_delta.md
+++ b/docs/MMAPI/hooks/player.health_delta.md
@@ -50,3 +50,4 @@ mmapi_filter("player.health_delta", iron_constitution_player_health_delta);
 - [player.stamina_delta](player.stamina_delta.md) - This is the same filter point for stamina.
 - [player.essence_delta](player.essence_delta.md) - The same filter family: essence, gold, mana, and skill XP each have theirs.
 - [player.heal_vfx](player.heal_vfx.md) - Veto the heal sparkle without touching the heal.
+- [player.died](player.died.md) - Know when the player dies.

--- a/docs/MMAPI/hooks/player.incoming_damage.md
+++ b/docs/MMAPI/hooks/player.incoming_damage.md
@@ -61,3 +61,4 @@ mmapi_filter("player.incoming_damage", stone_skin_player_incoming_damage);
 - [combat.damage_resolved](combat.damage_resolved.md) - Observe the hit after it resolves.
 - [combat.damage_injected](combat.damage_injected.md) - Observe synthetic hits from `mmapi_deal_damage()`.
 - [player.health_delta](player.health_delta.md) - This is the last filter the damage passes through, inside `modify_health`.
+- [player.died](player.died.md) - Know when the player dies.

--- a/docs/MMAPI/hooks/player.max_health_item.md
+++ b/docs/MMAPI/hooks/player.max_health_item.md
@@ -47,3 +47,4 @@ mmapi_on("player.max_health_item", vital_feast_player_max_health_item);
 - [items.consumed](items.consumed.md) - Know when the player eats any item, modifier or not.
 - [player.health_delta](player.health_delta.md) - Filter the item's regular `health_modifier` heal, which applies right after this event.
 - [ui.menu_refreshed](ui.menu_refreshed.md) - Know when the vitals menu rebuilds its content.
+- [player.acquire_perk](player.acquire_perk.md) - Know when the player acquires a perk.

--- a/docs/MMAPI/hooks/player.pass_out.md
+++ b/docs/MMAPI/hooks/player.pass_out.md
@@ -1,0 +1,47 @@
+# Hook: player.pass_out
+
+Know when the player passes out at the end of the day.
+
+`player.pass_out` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires in `pass_out()`, immediately after `end_day()`. The day rollover is already under way, stamina is zeroed, and the player is flagged invulnerable when handlers run. ctx is `{ faint }`.
+
+`faint` is `true` for the 2 AM collapse and `false` when the player went down to a killing blow but the death was averted. `ARI.end_of_day_status` tells the cases apart. `EndOfDayStatus.Fainted` for the plain collapse, `EndOfDayStatus.Protected` otherwise. This hook is observation only. A normal bed sleep ends the day without `pass_out()`, and a death that is not averted runs the dying scene instead. See [player.died](player.died.md).
+
+| | |
+| --- | --- |
+| **Fires** | In `pass_out()`, immediately after `end_day()` has run. |
+| **ctx** | `{ faint }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `faint` - `true` for the 2 AM collapse, `false` for an averted death. Read `ARI.end_of_day_status` (`Fainted`, `Protected`) to tell the cases apart.
+
+## Usage
+
+```gml
+// player.pass_out is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function night_ledger_player_pass_out(_ctx) {
+    // _ctx is { faint }.
+    //   .faint - true for the 2 AM collapse, false for an averted death.
+    // end_day() has already run: the end-of-day sequence is committed.
+    // if (_ctx.faint && ARI.end_of_day_status == EndOfDayStatus.Fainted) { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("player.pass_out", night_ledger_player_pass_out);
+```
+
+## Engine Wiring
+
+- Seam [`player_pass_out`](../seams/player_pass_out.md) dispatches from `gml/scripts/Player/pass_out.gml`, immediately after the `end_day();` call.
+
+## See Also
+
+- [player.died](player.died.md) - This is the death path that never reaches `pass_out()`.
+- [game.new_day](game.new_day.md) - Know the moment the engine's new-day logic has run, before the end-of-day autosave.
+- [player.stamina_delta](player.stamina_delta.md) - Change every stamina cost or gain before it applies.

--- a/docs/MMAPI/hooks/player.renown_delta.md
+++ b/docs/MMAPI/hooks/player.renown_delta.md
@@ -53,3 +53,6 @@ mmapi_filter("player.renown_delta", town_favorite_player_renown_delta);
 - [player.xp_delta](player.xp_delta.md) - The similar filter point for skill XP.
 - [player.gold_delta](player.gold_delta.md) - The filter point for the shipping gold that becomes a renown entry.
 - [npc.heart_points](npc.heart_points.md) - The equivalent delta filter for villager hearts.
+- [museum.donate_item](museum.donate_item.md) - The donation moment that queues one of the pending entries this filter drains.
+- [quest.complete](quest.complete.md) - The quest completion moment that queues another kind of pending entry.
+- [renown.level_gained](renown.level_gained.md) - The level-up moment the drained gains produce, downstream in `set_renown()`.

--- a/docs/MMAPI/hooks/player.skill_leveled.md
+++ b/docs/MMAPI/hooks/player.skill_leveled.md
@@ -1,0 +1,53 @@
+# Hook: player.skill_leveled
+
+Know the moment the player levels up a skill.
+
+`player.skill_leveled` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires in `gain_xp()` when the applied XP raises the skill's level, right after the new total is written and before the level-up celebration. ctx is `{ skill, old_level, new_level, silent }`.
+
+`silent` is `gain_xp`'s own flag, and the emit sits outside its gate, so silent engine gains (crafting XP, stable breeding) fire too, celebration or not. A level lowered through a negative [player.xp_delta](player.xp_delta.md) replacement never fires this hook. A single large gain can cross several levels and still fires once, so compare `old_level` and `new_level` rather than assuming a step of one. Save load and the debug menu write `skill_xp` directly and never fire.
+
+| | |
+| --- | --- |
+| **Fires** | In `gain_xp()`, right after the XP write raises the skill's level, before the celebration. |
+| **ctx** | `{ skill, old_level, new_level, silent }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `skill` - the `Skill` enum id that leveled.
+- `old_level` - the level before the XP applied.
+- `new_level` - the level after (a big gain can cross more than one).
+- `silent` - `gain_xp`'s celebration-skip flag. The event fires either way.
+
+## Usage
+
+```gml
+// player.skill_leveled is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function milestone_bells_player_skill_leveled(_ctx) {
+    // _ctx is { skill, old_level, new_level, silent }.
+    //   .skill     - the Skill enum id that leveled.
+    //   .old_level - the level before the gain.
+    //   .new_level - the level after (may have crossed several).
+    //   .silent    - true for celebration-skipping gains (crafting, breeding).
+    // Fires once per leveling gain, never on plain XP ticks.
+    // if (_ctx.skill == Skill.Cooking && _ctx.new_level >= 10) { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("player.skill_leveled", milestone_bells_player_skill_leveled);
+```
+
+## Engine Wiring
+
+- Seam [`player_xp_delta`](../seams/player_xp_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, inside `gain_xp()` right after the capped XP write. The same edit filters [player.xp_delta](player.xp_delta.md) at the function's head.
+
+## See Also
+
+- [player.xp_delta](player.xp_delta.md) - Change every skill XP gain before it applies, the filter that decides whether this event fires.
+- [renown.level_gained](renown.level_gained.md) - This event is the renown counterpart of this moment.
+- [player.acquire_perk](player.acquire_perk.md) - Know when the player acquires a perk.

--- a/docs/MMAPI/hooks/player.stamina_delta.md
+++ b/docs/MMAPI/hooks/player.stamina_delta.md
@@ -48,3 +48,4 @@ mmapi_filter("player.stamina_delta", tireless_player_stamina_delta);
 - [player.health_delta](player.health_delta.md) - The similar filter point for health.
 - [player.mana_delta](player.mana_delta.md) - The similar filter point for mana.
 - [player.move_speed](player.move_speed.md) - Change the player's move speed after every engine modifier.
+- [player.pass_out](player.pass_out.md) - Know when the player passes out at the end of the day.

--- a/docs/MMAPI/hooks/player.xp_delta.md
+++ b/docs/MMAPI/hooks/player.xp_delta.md
@@ -47,10 +47,11 @@ mmapi_filter("player.xp_delta", battle_scholar_player_xp_delta);
 
 ## Engine Wiring
 
-- Seam [`player_xp_delta`](../seams/player_xp_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `gain_xp(skill, xp, silent)`, filtering `xp` and flooring the result before the engine's capped add. The same edit narrows the level celebration from any level change to a genuine gain.
+- Seam [`player_xp_delta`](../seams/player_xp_delta.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, at the head of `gain_xp(skill, xp, silent)`, filtering `xp` and flooring the result before the engine's capped add. The same edit narrows the level celebration from any level change to a genuine gain and emits [player.skill_leveled](player.skill_leveled.md) when the write raises the level.
 
 ## See Also
 
 - [player.essence_delta](player.essence_delta.md) - The similar filter shape for essence change.
 - [npc.heart_points](npc.heart_points.md) - The equivalent delta filter for villager hearts.
 - [animal.heart_points](animal.heart_points.md) - The equivalent delta filter for barn animals.
+- [player.skill_leveled](player.skill_leveled.md) - The level-up event the same seam emits after this filter's delta applies.

--- a/docs/MMAPI/hooks/quest.complete.md
+++ b/docs/MMAPI/hooks/quest.complete.md
@@ -1,0 +1,50 @@
+# Hook: quest.complete
+
+Know when a quest is completed.
+
+`quest.complete` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires inside `QuestLog.complete(quest_name)`, after the completion is validated (the quest is active and its final task is done) and before any completion bookkeeping. The `T2R` quest facts, the active-to-completed move, the request-board cleanup, the pending renown entry, and the achievements refresh all land after the emit. Calls that fail validation return early and never fire, so every emit is a genuine completion.
+
+ctx is `{ quest_name, quest }`. `quest` is the `ActiveQuest` being completed. Its prototype is `quest.quest` and its rewards `quest.quest.reward_list`. This hook is observation only. At emit time the quest still counts as active (`QUEST_LOG.active` holds it, `QUEST_LOG.completed` does not), which is how a handler can distinguish "completing right now" from "already completed".
+
+| | |
+| --- | --- |
+| **Fires** | Inside `QuestLog.complete()`, after validation, before the completion bookkeeping. |
+| **ctx** | `{ quest_name, quest }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `quest_name` - the quest's key string.
+- `quest` - the `ActiveQuest` being completed. `quest.quest` is the quest prototype, `quest.quest.reward_list` its rewards, and `quest.current_stage` the finished stage count.
+
+## Usage
+
+```gml
+// quest.complete is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function quest_scribe_quest_complete(_ctx) {
+    // _ctx is { quest_name, quest }.
+    //   .quest_name - the quest's key string.
+    //   .quest      - the ActiveQuest. .quest.quest is the prototype,
+    //                 .quest.quest.reward_list its rewards.
+    // Validation has passed: this is a real completion, about to be recorded.
+    // if (_ctx.quest_name == "<your quest key>") { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("quest.complete", quest_scribe_quest_complete);
+```
+
+## Engine Wiring
+
+- Seam [`quest_complete`](../seams/quest_complete.md) dispatches from `gml/scripts/GameplaySystems/Quests/QuestLog.gml`, inside `complete()` below the validation early-return, anchored on the first `T2R` fact write.
+
+## See Also
+
+- [player.renown_delta](player.renown_delta.md) - This filter is where a renown-rewarding quest's pending entry lands at day rollover.
+- [request_board.fetch_pool](request_board.fetch_pool.md) - Change the request board's daily candidate pool and draw cap.
+- [museum.donate_item](museum.donate_item.md) - This event is the other progression moment that queues a pending renown entry.

--- a/docs/MMAPI/hooks/renown.level_gained.md
+++ b/docs/MMAPI/hooks/renown.level_gained.md
@@ -1,0 +1,50 @@
+# Hook: renown.level_gained
+
+Know the moment the player gains a renown level.
+
+`renown.level_gained` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires inside `Ari.set_renown()` when the write raises the renown level, past the gains-only early return and before the crossed levels' rewards are granted. ctx is `{ old_level, new_level }`.
+
+A single write can cross several levels and still fires once, so compare the two ctx fields. The engine's gameplay path here is the day-rollover drain of pending renown entries, each already filtered through [player.renown_delta](player.renown_delta.md), and debug sets route through `set_renown` too. Save load restores the renown field directly and never fires. Losses and level-neutral writes never fire either. `set_renown` bails before the emit unless the level rose.
+
+| | |
+| --- | --- |
+| **Fires** | Inside `Ari.set_renown()`, when the write raises the level, before the level rewards are granted. |
+| **ctx** | `{ old_level, new_level }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `old_level` - the renown level before the write.
+- `new_level` - the level after (a big gain can cross more than one).
+
+## Usage
+
+```gml
+// renown.level_gained is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function town_herald_renown_level_gained(_ctx) {
+    // _ctx is { old_level, new_level }.
+    //   .old_level - the renown level before the write.
+    //   .new_level - the level after (may have crossed several).
+    // Fires at day rollover as the pending entries drain, once per
+    // leveling write. The level rewards land right after the emit.
+    // if (_ctx.new_level >= 50) { ... }
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("renown.level_gained", town_herald_renown_level_gained);
+```
+
+## Engine Wiring
+
+- Seam [`renown_gains`](../seams/renown_gains.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, inside `set_renown()` below its gains-only early return. The same seam emits [renown.rank_gained](renown.rank_gained.md) when the gain crosses a rank boundary.
+
+## See Also
+
+- [renown.rank_gained](renown.rank_gained.md) - Know when a gain crosses a rank boundary, from the same seam.
+- [player.renown_delta](player.renown_delta.md) - Change every renown gain before it applies, upstream of this event.
+- [player.skill_leveled](player.skill_leveled.md) - This event is the skill counterpart of this moment.

--- a/docs/MMAPI/hooks/renown.rank_gained.md
+++ b/docs/MMAPI/hooks/renown.rank_gained.md
@@ -1,0 +1,48 @@
+# Hook: renown.rank_gained
+
+Know the moment the player reaches a new renown rank.
+
+`renown.rank_gained` is an **event** hook. Register a callback with `mmapi_on`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires inside `Ari.set_renown()` when a renown level gain crosses a rank boundary, immediately after [renown.level_gained](renown.level_gained.md). ctx is `{ old_rank, new_rank }`, each as the integer indexes into `RENOWN.ranks`, so `RENOWN.ranks.get(new_rank)` is the rank struct with its name and sprites.
+
+A gain within one rank fires `renown.level_gained` alone, and once the final rank is reached, further level gains never fire this hook again. The same caller notes apply as for its sibling. The gameplay path is the day-rollover drain, debug sets also route through, and save load never fires.
+
+| | |
+| --- | --- |
+| **Fires** | Inside `Ari.set_renown()`, when a level gain crosses a rank boundary, right after `renown.level_gained`. |
+| **ctx** | `{ old_rank, new_rank }` |
+| **Kind contract** | The callback observes the moment. Its return value is ignored. |
+
+### The ctx struct
+
+- `old_rank` - the rank index before the gain.
+- `new_rank` - the rank index after, clamped to the last rank. `RENOWN.ranks.get(new_rank)` resolves the struct.
+
+## Usage
+
+```gml
+// renown.rank_gained is an EVENT: the return value is ignored.
+// You cannot change or stop it here; the return value is ignored.
+function rank_banner_renown_rank_gained(_ctx) {
+    // _ctx is { old_rank, new_rank }.
+    //   .old_rank - the rank index before the gain.
+    //   .new_rank - the rank index after, clamped to the last rank.
+    // RENOWN.ranks.get(_ctx.new_rank) is the rank struct (name, sprites).
+    // Fires only when a boundary is crossed, so no latch is needed.
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_on("renown.rank_gained", rank_banner_renown_rank_gained);
+```
+
+## Engine Wiring
+
+- Seam [`renown_gains`](../seams/renown_gains.md) dispatches from `gml/scripts/GameplaySystems/Player/Ari.gml`, inside `set_renown()` below its gains-only early return, behind a rank-boundary comparison.
+
+## See Also
+
+- [renown.level_gained](renown.level_gained.md) - Know every renown level gain, boundary or not, from the same seam.
+- [player.renown_delta](player.renown_delta.md) - Change every renown gain before it applies, upstream of this event.

--- a/docs/MMAPI/hooks/request_board.fetch_pool.md
+++ b/docs/MMAPI/hooks/request_board.fetch_pool.md
@@ -54,3 +54,4 @@ mmapi_filter("request_board.fetch_pool", bigger_board_request_board_fetch_pool);
 
 - [request_board.fetch_pool_ready](request_board.fetch_pool_ready.md) - Observe the finished board after the final availability pass.
 - [game.new_day](game.new_day.md) - The day rollover this build rides on.
+- [quest.complete](quest.complete.md) - Know when a quest is completed.

--- a/docs/MMAPI/hooks/store.item_added.md
+++ b/docs/MMAPI/hooks/store.item_added.md
@@ -54,3 +54,4 @@ mmapi_on("store.item_added", basket_bundler_store_item_added);
 
 - [items.give](items.give.md) - Rewrite any item the player is about to receive.
 - [ui.menu_opened](ui.menu_opened.md) - Know when a menu (the store included) opens.
+- [museum.donate_item](museum.donate_item.md) - Know when an item is donated to the museum.

--- a/docs/MMAPI/hooks/ui.menu_opened.md
+++ b/docs/MMAPI/hooks/ui.menu_opened.md
@@ -43,3 +43,4 @@ mmapi_on("ui.menu_opened", menu_greeter_ui_menu_opened);
 
 - [ui.menu_closed](ui.menu_closed.md) - Know when a menu closes.
 - [ui.menu_refreshed](ui.menu_refreshed.md) - React when a menu rebuilds its content.
+- [ui.spawn_tutorial_guard](ui.spawn_tutorial_guard.md) - Block a tutorial popup before it spawns.

--- a/docs/MMAPI/hooks/ui.spawn_tutorial_guard.md
+++ b/docs/MMAPI/hooks/ui.spawn_tutorial_guard.md
@@ -1,0 +1,50 @@
+# Hook: ui.spawn_tutorial_guard
+
+Block a tutorial popup before it spawns.
+
+`ui.spawn_tutorial_guard` is a **guard** hook. Register a callback with `mmapi_guard`. See [Hooks](../HOOKS.md) for how registration and dispatch work.
+
+## Contract
+
+Fires at the top of `spawn_tutorial(tutorial)`, before the tutorial is marked seen and before its popup is built. ctx is `{ tutorial }`, the `Tutorial` enum id. Return `false` to veto the popup (`spawn_tutorial` returns `undefined`). Every other return allows.
+
+A vetoed tutorial stays unmarked in `ARI.tutorials_seen`, so the game offers it again on its next trigger. A handler that wants a tutorial gone for good must veto every time (cheap), or mark it seen itself. The guard sits above the function's own test-suite early return, so it also fires, vacuously, in test-suite runs.
+
+| | |
+| --- | --- |
+| **Fires** | At the top of `spawn_tutorial(tutorial)`, before the seen-flag write and the popup build. |
+| **ctx** | `{ tutorial }` |
+| **Kind contract** | Only the Boolean value `false` vetoes. Every other return allows. Guards fail open: a callback that throws counts as allow. |
+
+### The ctx struct
+
+- `tutorial` - the `Tutorial` enum id about to be shown.
+
+## Usage
+
+```gml
+// ui.spawn_tutorial_guard is a GUARD: return Boolean false to block it;
+// every other return allows. Guards fail OPEN - if your handler crashes, the action happens.
+function seasoned_farmer_ui_spawn_tutorial_guard(_ctx) {
+    // _ctx is { tutorial }.
+    //   .tutorial - the Tutorial enum id about to be shown.
+    // A vetoed tutorial is NOT marked seen, so it will try again on its
+    // next trigger. Keep vetoing (or set ARI.tutorials_seen yourself).
+    // if (<your condition>) {
+    //     return false; // veto - spawn_tutorial returns undefined
+    // }
+    return undefined; // allow everything else
+}
+
+// inside your latched register function (see Mod Anatomy):
+mmapi_guard("ui.spawn_tutorial_guard", seasoned_farmer_ui_spawn_tutorial_guard);
+```
+
+## Engine Wiring
+
+- Seam [`ui_spawn_tutorial_guard`](../seams/ui_spawn_tutorial_guard.md) dispatches from `gml/scripts/UI/Anchor/anchor_utils.gml`, at the head of `spawn_tutorial()`. On veto the engine runs `return undefined;`.
+
+## See Also
+
+- [ui.menu_opened](ui.menu_opened.md) - Know the moment a menu opens.
+- [dialogue.play_guard](dialogue.play_guard.md) - Block a conversation before it starts, the same veto shape.

--- a/docs/MMAPI/seams/dialogue_play_guard.md
+++ b/docs/MMAPI/seams/dialogue_play_guard.md
@@ -28,3 +28,4 @@ This entry sits near the end of the catalog on purpose. Catalog order is apply o
 - [dialogue.play_guard](../hooks/dialogue.play_guard.md) - This is the hook this seam dispatches.
 - [dialogue_path](dialogue_path.md) - This is the filter this guard runs ahead of, in the same function.
 - [dialogue_line](dialogue_line.md) - Reword lines of conversations you let through.
+- [ui_spawn_tutorial_guard](ui_spawn_tutorial_guard.md) - This is the same veto shape in front of tutorial popups.

--- a/docs/MMAPI/seams/museum_donate_item.md
+++ b/docs/MMAPI/seams/museum_donate_item.md
@@ -1,0 +1,28 @@
+# Seam: museum_donate_item
+
+Emits the moment an item is donated to the museum.
+
+`museum_donate_item` is a **template seam** (`op = "emit"`). It feeds [museum.donate_item](../hooks/museum.donate_item.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/Museum.gml` |
+| **Locator** | structural target: `donate_item_to_museum`, at head |
+| **Op** | `emit` |
+| **Feeds** | [`museum.donate_item`](../hooks/museum.donate_item.md) |
+| **ctx built** | `{ item_id: item_id }` |
+| **Marker** | `mmapi_museum_donate_item` |
+
+## The Edit
+
+The generated emit lands at the head of `donate_item_to_museum()`. It calls `mmapi_emit("museum.donate_item", { item_id: item_id })` in the uniform try/catch shape. The head placement puts the emit before everything the donation does: `register_item_to_museum()` (the progress write and its `T2R` fact), the pending renown entry push, and the set-progress scan that decides the `DonationResult`.
+
+`donate_item_to_museum()` is the donation menu's single entry point, so the hook sees exactly the player's donations (plus those of the engine's test suite). The engine's two other progress writers, save load and the `ALL_UNLOCKS` new-game path, call `register_item_to_museum()` directly, below this seam's reach. That is what keeps load-time restoration from replaying as donations. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [museum.donate_item](../hooks/museum.donate_item.md) - This is the hook this seam dispatches.
+- [player_renown_delta](player_renown_delta.md) - This is the filter the donation's pending renown entry drains through at day rollover.
+- [quest_complete](quest_complete.md) - This is the other progression emit that queues a pending renown entry.

--- a/docs/MMAPI/seams/new_day_complete.md
+++ b/docs/MMAPI/seams/new_day_complete.md
@@ -26,3 +26,4 @@ The engine's debug and test-suite `new_day()` callers route through the same fun
 - [game.new_day](../hooks/game.new_day.md) - This is the hook this seam dispatches.
 - [save_game_saving](save_game_saving.md) - This seam's emit is the next mod-visible moment on the end-of-day path, when the autosave commits.
 - [game_step_begin_installs](game_step_begin_installs.md) - This engine fix drives the poll that derives [game.day_changed](../hooks/game.day_changed.md), the observation-side counterpart.
+- [player_pass_out](player_pass_out.md) - This is the emit inside `pass_out()`, right after `end_day()`.

--- a/docs/MMAPI/seams/player_acquire_perk.md
+++ b/docs/MMAPI/seams/player_acquire_perk.md
@@ -1,0 +1,28 @@
+# Seam: player_acquire_perk
+
+Emits at the head of `acquire_perk()`.
+
+`player_acquire_perk` is a **template seam** (`op = "emit"`). It feeds [player.acquire_perk](../hooks/player.acquire_perk.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | structural target: `acquire_perk`, at head |
+| **Op** | `emit` |
+| **Feeds** | [`player.acquire_perk`](../hooks/player.acquire_perk.md) |
+| **ctx built** | `{ perk: perk }` |
+| **Marker** | `mmapi_player_acquire_perk` |
+
+## The Edit
+
+The generated emit lands at the head of the `Ari` struct's `acquire_perk(perk)`. It calls `mmapi_emit("player.acquire_perk", { perk: perk })` in the uniform try/catch shape. The head placement is what lets a handler read `ARI.perks[perk]` pre-write. The owned and active flags, the per-perk side effects (Guardian's Shield, Ancient Inspiration), the stats entry, and the achievements refresh all run after the emit.
+
+Every engine acquisition routes through this one method: the Dragonshrine purchase menu, the debug CLI, and the `ALL_UNLOCKS` grant-all loop. Save load writes the perk arrays wholesale and never calls it, and the enable/disable toggles (the shrine menu's and the debug CLI's) flip `perks_active` directly, so toggles never emit either. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [player.acquire_perk](../hooks/player.acquire_perk.md) - This is the hook this seam dispatches.
+- [player_heal_vfx](player_heal_vfx.md) - This is the neighboring guard in the same file.
+- [player_essence_delta](player_essence_delta.md) - This is the filter the Dragonshrine purchase's essence cost passes through, right before this emit.

--- a/docs/MMAPI/seams/player_died.md
+++ b/docs/MMAPI/seams/player_died.md
@@ -1,0 +1,28 @@
+# Seam: player_died
+
+Emits on the final death path, right after the dying scene starts.
+
+`player_died` is a **template seam** (`op = "emit"`). It feeds [player.died](../hooks/player.died.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/objects/characters/obj_ari.gml` |
+| **Locator** | structural target: `should_die`, at after `MIST.run_scene("dying");` |
+| **Op** | `emit` |
+| **Feeds** | [`player.died`](../hooks/player.died.md) |
+| **ctx built** | `self` (the `obj_ari` instance) |
+| **Marker** | `mmapi_player_died` |
+
+## The Edit
+
+The generated emit lands inside `should_die()`, in the screen-fade callback's else branch, immediately after `MIST.run_scene("dying");`. It calls `mmapi_emit("player.died", self)` in the uniform try/catch shape. The anchor sits two closures deep (the FSM's `on_start_action`, then the `SCREEN_FADER.fade_out` callback), which is why the emit fires only after the death animation has held and the fade has completed. Both closures are created in the instance's scope, so `self` is the `obj_ari` instance when the emit runs.
+
+The branch placement encodes the hook's meaning. `should_die()` returns early for health above zero and for the Fairy status revive, and its averted-death branch calls `pass_out()` instead of running the scene, so none of those paths reach the emit. It fires exactly when the dying scene starts. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [player.died](../hooks/player.died.md) - This is the hook this seam dispatches.
+- [player_pass_out](player_pass_out.md) - This is the sibling emit on the collapse and averted-death paths.
+- [player_incoming_damage](player_incoming_damage.md) - This is the filter on the damage that gets the player here.

--- a/docs/MMAPI/seams/player_heal_vfx.md
+++ b/docs/MMAPI/seams/player_heal_vfx.md
@@ -26,3 +26,4 @@ The locator is structural (function + head, matched token-wise), immune to white
 
 - [player.heal_vfx](../hooks/player.heal_vfx.md) - This is the hook this seam dispatches.
 - [player_health_delta](player_health_delta.md) - This is the filter on the health change itself, in the same file.
+- [player_acquire_perk](player_acquire_perk.md) - This is the emit at the head of `acquire_perk()`, in the same file.

--- a/docs/MMAPI/seams/player_incoming_damage.md
+++ b/docs/MMAPI/seams/player_incoming_damage.md
@@ -32,3 +32,4 @@ This is the largest text rewrite in the combat set. Pristine code sets `took_dam
 - [player.incoming_damage](../hooks/player.incoming_damage.md) - This is the hook this seam dispatches.
 - [combat_damage_pre](combat_damage_pre.md) - This is where a `combat.damage` filter sets the popup/flinch fields this seam reads.
 - [player_health_delta](player_health_delta.md) - This is the general filter inside the `modify_health` call this seam gates.
+- [player_died](player_died.md) - This is the emit on the final death path.

--- a/docs/MMAPI/seams/player_pass_out.md
+++ b/docs/MMAPI/seams/player_pass_out.md
@@ -1,0 +1,28 @@
+# Seam: player_pass_out
+
+Emits inside `pass_out()`, right after `end_day()`.
+
+`player_pass_out` is a **template seam** (`op = "emit"`). It feeds [player.pass_out](../hooks/player.pass_out.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/Player/pass_out.gml` |
+| **Locator** | structural target: `pass_out`, at after `end_day();` |
+| **Op** | `emit` |
+| **Feeds** | [`player.pass_out`](../hooks/player.pass_out.md) |
+| **ctx built** | `{ faint: faint }` |
+| **Marker** | `mmapi_player_pass_out` |
+
+## The Edit
+
+The generated emit lands in `pass_out(faint)` immediately after the `end_day();` call. It calls `mmapi_emit("player.pass_out", { faint: faint })` in the uniform try/catch shape. The placement is a deliberate middle ground. The invulnerability flag, the stamina zeroing, and the day-end commit have happened, while the held-animal put-down, the faint stat and 2 AM notification, and the faint sound are still to come.
+
+`pass_out()` has exactly two kinds of caller in the engine: the 2 AM collapse paths (`faint = true`, from `should_faint()`'s swim and land variants) and the averted death (`faint = false`, from `should_die()`'s fade-out callback). A normal sleep ends the day without it, and a death that is not averted takes the dying scene instead. The emit's [player_died](player_died.md) sibling covers that branch. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [player.pass_out](../hooks/player.pass_out.md) - This is the hook this seam dispatches.
+- [player_died](player_died.md) - This is the sibling emit on the final death branch.
+- [new_day_complete](new_day_complete.md) - This is the emit inside the engine's new-day work that follows the day end.

--- a/docs/MMAPI/seams/player_renown_delta.md
+++ b/docs/MMAPI/seams/player_renown_delta.md
@@ -27,3 +27,6 @@ This seam sets `try_catch = false`. The dispatch is a direct assignment, not wra
 - [player.renown_delta](../hooks/player.renown_delta.md) - This is the hook this seam dispatches.
 - [player_gold_delta](player_gold_delta.md) - This seam is the same shape on `modify_gold()`.
 - [player_xp_delta](player_xp_delta.md) - The other progression delta, where the engine has no floor and the seam supplies one.
+- [museum_donate_item](museum_donate_item.md) - This is the emit at the head of a museum donation, one source of the pending entries this filter drains.
+- [quest_complete](quest_complete.md) - This is the emit inside a validated quest completion, the other pending-entry source.
+- [renown_gains](renown_gains.md) - This is the emit downstream in `set_renown()`, where a drained gain's level-ups land.

--- a/docs/MMAPI/seams/player_xp_delta.md
+++ b/docs/MMAPI/seams/player_xp_delta.md
@@ -1,8 +1,8 @@
 # Seam: player_xp_delta
 
-Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and narrows the level celebration to genuine gains.
+Filters the XP delta at the head of `gain_xp()`, floors the total at zero, narrows the level celebration to genuine gains, and emits the skill level-up.
 
-`player_xp_delta` is a **text seam** (`anchor` + `replace`). It feeds [player.xp_delta](../hooks/player.xp_delta.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+`player_xp_delta` is a **text seam** (`anchor` + `replace`). It feeds [player.xp_delta](../hooks/player.xp_delta.md) and [player.skill_leveled](../hooks/player.skill_leveled.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
 
 ## Placement
 
@@ -11,21 +11,23 @@ Filters the XP delta at the head of `gain_xp()`, floors the total at zero, and n
 | **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
 | **Locator** | text anchor spanning `gain_xp(skill, xp, silent)` from its head through the level-celebration condition |
 | **Op** | text (`anchor` + `replace`) |
-| **Feeds** | [`player.xp_delta`](../hooks/player.xp_delta.md) |
+| **Feeds** | [`player.xp_delta`](../hooks/player.xp_delta.md), [`player.skill_leveled`](../hooks/player.skill_leveled.md) |
 | **Value filtered** | `xp` - the XP delta |
 | **ctx built** | `{ player: self, skill: skill, silent: silent }` |
 | **Marker** | `mmapi_player_run_xp_delta_filters` |
 
 ## The Edit
 
-One anchor, two changes, both unreachable in vanilla:
+One anchor, three changes, the first two unreachable in vanilla:
 
 1. **The filter, with its floor.** At the head of `gain_xp()`, the replacement runs `mmapi_apply_filters("player.xp_delta", xp, { player: self, skill: skill, silent: silent })` in a try/catch, adopts the result only when it is numeric (`is_real` or `is_int64`), and floors the adopted value at `-self.skill_xp[skill]`. The engine's capped add - `min(skill_xp[skill] + xp, MAX_SKILL_LEVEL_COSTS[skill])` - then runs on the filtered delta. The floor matters because the engine has no lower clamp of its own and `skill_xp_to_level()` reads a negative total as level `-1`; floored at zero total, the computed level bottoms out at 1, since levels 0 and 1 cost 0 XP.
 2. **The celebration narrows.** Pristine celebrates any level change: `if !silent && old_skill_level != ARI.level(skill)` plays the LevelUp sound and spawns the skill dingaling. The replacement changes `!=` to `<`, so a level *down* - reachable only through this hook's negative deltas - passes silently instead of playing a level-up fanfare.
+3. **The level-up emits.** Between the capped write and the celebration, the replacement compares the level before and after and emits `mmapi_emit("player.skill_leveled", { skill, old_level, new_level, silent })` when it rose. The emit sits outside the `!silent` gate on purpose. Crafting XP and stable breeding gain silently, and a level-up there is still a level-up.
 
-With zero handlers both changes are behaviorally equivalent to pristine: every vanilla delta is non-negative, so the floor never binds and the `<` condition agrees with `!=` everywhere vanilla can reach. `gain_xp` is the engine's sole gameplay XP writer - combat, farming, fishing, mining, archaeology, ranching, and cooking all call it - so one edit filters every skill's XP. Save load and the debug menu write `skill_xp` directly and never pass through.
+With zero handlers all three changes are behaviorally equivalent to pristine. Every vanilla delta is non-negative, so the floor never binds, the `<` condition agrees with `!=` everywhere vanilla can reach, and the emit dispatches to nobody. `gain_xp` is the engine's sole gameplay XP writer - combat, farming, fishing, mining, archaeology, ranching, and cooking all call it - so one edit filters every skill's XP. Save load and the debug menu write `skill_xp` directly and never pass through.
 
 ## See Also
 
-- [player.xp_delta](../hooks/player.xp_delta.md) - This is the hook this seam dispatches.
+- [player.xp_delta](../hooks/player.xp_delta.md) - This is the filter this seam dispatches.
+- [player.skill_leveled](../hooks/player.skill_leveled.md) - This is the level-up event the same edit emits.
 - [player_essence_delta](player_essence_delta.md) - This seam's sibling: the other delta filter that carries its own floor.

--- a/docs/MMAPI/seams/quest_complete.md
+++ b/docs/MMAPI/seams/quest_complete.md
@@ -1,0 +1,29 @@
+# Seam: quest_complete
+
+Emits inside `QuestLog.complete()` once the completion is validated, before the bookkeeping runs.
+
+`quest_complete` is a **template seam** (`op = "emit"`). It feeds [quest.complete](../hooks/quest.complete.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Quests/QuestLog.gml` |
+| **Locator** | structural target: `complete`, at before `T2R.write(format("quest_{}_in_progress", quest_name), false);` |
+| **Op** | `emit` |
+| **Feeds** | [`quest.complete`](../hooks/quest.complete.md) |
+| **ctx built** | `{ quest_name: quest_name, quest: finished_quest }` |
+| **Marker** | `mmapi_quest_complete` |
+
+## The Edit
+
+The generated emit lands inside the `QuestLog` struct's `complete(quest_name)`, anchored on the first `T2R` fact write. It calls `mmapi_emit("quest.complete", { quest_name: quest_name, quest: finished_quest })` in the uniform try/catch shape. The anchor choice, below the validation early-return rather than at head, is the point of the seam. `complete()` bails with `undefined` when the quest is not active or its final task is not done (defensive re-completes from the debug CLI, or mod GML, land there), and only calls that pass fire the hook. It also puts `finished_quest`, the looked-up `ActiveQuest`, in scope and non-`undefined` for the ctx.
+
+Everything that makes the completion real happens after the emit: both `T2R` quest facts, the active-to-completed move, the completion timestamp, the request-board cleanup, the pending renown entry for renown-rewarding quests, and the achievements refresh. Every engine completion routes through this one method: stage progression, festivals, the seal tablet, renown level quests, and the debug CLI alike. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [quest.complete](../hooks/quest.complete.md) - This is the hook this seam dispatches.
+- [player_renown_delta](player_renown_delta.md) - This is the filter a renown-rewarding quest's pending entry drains through.
+- [request_board_fetch_pool_ready](request_board_fetch_pool_ready.md) - This is the emit of the finished daily request board.
+- [museum_donate_item](museum_donate_item.md) - This is the other progression emit that queues a pending renown entry.

--- a/docs/MMAPI/seams/renown_gains.md
+++ b/docs/MMAPI/seams/renown_gains.md
@@ -1,0 +1,29 @@
+# Seam: renown_gains
+
+Emits renown level and rank gains inside `set_renown()`, past its gains-only early return.
+
+`renown_gains` is a **text seam** (`anchor` + `replace`). It feeds [renown.level_gained](../hooks/renown.level_gained.md) and [renown.rank_gained](../hooks/renown.rank_gained.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/GameplaySystems/Player/Ari.gml` |
+| **Locator** | text anchor inside `set_renown()`: the gains-only early return plus the rewards-count line that follows it |
+| **Feeds** | [`renown.level_gained`](../hooks/renown.level_gained.md), [`renown.rank_gained`](../hooks/renown.rank_gained.md) |
+| **ctx built** | `{ old_level: level, new_level: new_level }` and `{ old_rank, new_rank }` |
+| **Marker** | `mmapi_renown_run_gains` |
+
+## The Edit
+
+The injected emits land between `set_renown()`'s early return and the reward loop. The pristine function computes the level before and after the write and bails with `if sign(new_levels) != 1`, so only writes that raise the level reach this point. That is the placement doing the semantic work. The hooks' names promise gains, and the engine's own gate delivers them.
+
+The first line emits `renown.level_gained` with the before and after levels. The second block computes the before and after rank indexes (`level div RENOWN.levels_per_rank`, clamped to the last rank the way `renown_level_to_rank()` clamps) and emits `renown.rank_gained` only when they differ. This is a text seam because that boundary comparison is a conditional the template ops cannot express. Both emits run before the crossed levels' rewards are granted and before the renown level quests start.
+
+`set_renown` is where every renown write lands. The day-rollover drain arrives through `modify_renown` (already filtered by [player.renown_delta](../hooks/player.renown_delta.md)), and debug sets call it directly. Save load restores the field without calling it, so loading never replays gains. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [renown.level_gained](../hooks/renown.level_gained.md) - This is the first hook this seam dispatches.
+- [renown.rank_gained](../hooks/renown.rank_gained.md) - This is the second, behind the rank-boundary comparison.
+- [player_renown_delta](player_renown_delta.md) - This is the filter upstream in `modify_renown()`, before any write reaches `set_renown()`.

--- a/docs/MMAPI/seams/request_board_fetch_pool_ready.md
+++ b/docs/MMAPI/seams/request_board_fetch_pool_ready.md
@@ -24,3 +24,4 @@ The emit lands between `randomize()` and the return, inside a try/catch, after t
 
 - [request_board.fetch_pool_ready](../hooks/request_board.fetch_pool_ready.md) - This is the hook this seam dispatches.
 - [request_board_fetch_pool](request_board_fetch_pool.md) - The companion filter earlier in the same build.
+- [quest_complete](quest_complete.md) - This is the emit inside a validated quest completion.

--- a/docs/MMAPI/seams/ui_menu_opened.md
+++ b/docs/MMAPI/seams/ui_menu_opened.md
@@ -24,3 +24,4 @@ ANCHOR's open path spawns the menu (`spawn(menu_id, arg1, ..., arg6)`), pushes i
 - [ui.menu_opened](../hooks/ui.menu_opened.md) - This is the hook this seam dispatches.
 - [ui_menu_closed_drain](ui_menu_closed_drain.md) - This is the closing edge on the per-frame drain.
 - [ui_menu_closed_shutdown](ui_menu_closed_shutdown.md) - This is the closing edge on anchor shutdown.
+- [ui_spawn_tutorial_guard](ui_spawn_tutorial_guard.md) - This is the veto check in front of tutorial popups.

--- a/docs/MMAPI/seams/ui_spawn_tutorial_guard.md
+++ b/docs/MMAPI/seams/ui_spawn_tutorial_guard.md
@@ -1,0 +1,29 @@
+# Seam: ui_spawn_tutorial_guard
+
+Puts a veto check at the head of `spawn_tutorial()`.
+
+`ui_spawn_tutorial_guard` is a **template seam** (`op = "guard"`). It feeds [ui.spawn_tutorial_guard](../hooks/ui.spawn_tutorial_guard.md). Mod authors never write seams. You register handlers for the hooks they dispatch. See [Seams](../SEAMS.md).
+
+## Placement
+
+| | |
+| --- | --- |
+| **File** | `gml/scripts/UI/Anchor/anchor_utils.gml` |
+| **Locator** | structural target: `spawn_tutorial`, at head |
+| **Op** | `guard` |
+| **Feeds** | [`ui.spawn_tutorial_guard`](../hooks/ui.spawn_tutorial_guard.md) |
+| **ctx built** | `{ tutorial: tutorial }` |
+| **On veto** | `return undefined;` |
+| **Marker** | `mmapi_ui_spawn_tutorial_guard` |
+
+## The Edit
+
+The generated dispatch lands at the head of `spawn_tutorial(tutorial)`. It calls `mmapi_check_guards("ui.spawn_tutorial_guard", { tutorial: tutorial })` in the uniform try/catch shape. When any guard returns `false`, the injected line runs `return undefined;` and the popup never builds. That is the same non-value the function's own test-suite early return produces, and no caller reads `spawn_tutorial`'s return, so a veto is indistinguishable from the function not having run.
+
+The head placement has one behavioral edge worth knowing. `ARI.tutorials_seen[tutorial] = true` is the first thing the pristine body writes, and a veto happens above it, so a blocked tutorial stays unseen and its trigger will offer it again. It also means the guard fires (vacuously) in test-suite runs, above the `TEST_SUITE` bail. With zero handlers the seam is behaviorally identical to pristine.
+
+## See Also
+
+- [ui.spawn_tutorial_guard](../hooks/ui.spawn_tutorial_guard.md) - This is the hook this seam dispatches.
+- [dialogue_play_guard](dialogue_play_guard.md) - This is the same veto shape in front of conversations.
+- [ui_menu_opened](ui_menu_opened.md) - This is the emit when the anchor spawns a menu.


### PR DESCRIPTION
Adds 9 hooks/seams for Archipelago use

New hooks:
- `museum.donate_item` (event) - listens when player donates museum item
- `player.acquire_perk` (event) - listens when player acquires perk
- `player.should_die` (event) - listens when player reaches 0 HP
- `player.skill_xp_to_level` (event) - listens when player levels up their skill
- `player.pass_out` (event) - listens when player passes out past 2am
- `quest.complete` (event) - listen when a quest is completed
- `renown.to_level` (event) - listens when game converts renown amount to level
- `renown.level_to_rank` (event) - listens when game converts renown level to rank
- `ui.spawn_tutorial_guard` (guard) - blocks tutorials from spawning

New seams:
- `donate_item_to_museum` (`Museum.gml`)
- `player_pass_out` (`Player/pass_out.gml`)
- `player_should_die` (`obj_ari.gml`)
- `player_skill_xp_to_level` (`Ari.gml`)
- `player_acquire_perk` (`Xp.gml`)
- `quest_complete` (`QuestLog.gml`)
- `renown_to_level` (`RenownUtils.gml`)
- `renown_level_to_rank` (`RenownUtils.gml`)
- `ui_spawn_tutorial_guard` (`anchor_utils.gml`)

Updated `docs/MMAPI/CATALOG.md`

**Notes:**
- Individual pages for the hooks/seams still need to be added
- Doesn't change vanilla behavior