### PR TITLE
add shrine related hooks, changes to acquire_perk hook

### DIFF
--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -50,8 +50,8 @@ version = 2
 # hook surface. Keep them in step when adding or removing entries; the
 # shipped-catalog test also holds the docs' count sentences to these numbers.
 [counts]
-hooks = 129
-seams = 140
+hooks = 131
+seams = 142
 engine_fixes = 7
 call_rewrites = 1
 
@@ -702,6 +702,17 @@ doc  = "Fires once per NPC row as the relationships journal page builds its scro
 name = "ui.spawn_tutorial_guard"
 kind = "guard"
 doc  = "Fires at the top of spawn_tutorial(tutorial), before the tutorial is marked seen and before its popup is built. ctx is { tutorial }, the Tutorial enum id. Return false to veto the popup (spawn_tutorial returns undefined, and the tutorial stays unmarked in ARI.tutorials_seen, so the game offers it again on its next trigger); undefined or true allows. The guard sits above the function's own test-suite early return, so it also fires - vacuously - in test-suite runs."
+
+[[hook]]
+name = "ui.entry_enabled_guard"
+kind = "guard"
+doc  = "Fires at the top of entry_is_enabled(entry), in DragonShrineMenu. ctx is { entry.perk }."
+
+
+[[hook]]
+name = "ui.entry_acquired_guard"
+kind = "guard"
+doc  = "Fires at the top of entry_is_acquired(entry), in DragonShrineMenu. ctx is { entry.perk }."
 
 [[hook]]
 name = "ui.backplate_sprite"
@@ -3542,7 +3553,7 @@ marker  = "mmapi_ui_spawn_tutorial_guard"
 [[seam]]
 id      = "player_acquire_perk"
 file    = "gml/scripts/GameplaySystems/Player/Ari.gml"
-target  = { fn = "acquire_perk", at = "head" }
+target  = { fn = "acquire_perk", at = "after", anchor = '''self.perks_active[perk] = true;''' }
 op      = "emit"
 hook    = "player.acquire_perk"
 ctx     = "{ perk: perk }"
@@ -3755,3 +3766,23 @@ op      = "emit"
 hook    = "player.purchase_perk"
 ctx     = "{ perk: entry.perk }"
 marker  = "mmapi_dragonshrine_purchase_entry"
+
+[[seam]]
+id      = "ui_entry_is_enabled"
+file    = "gml/scripts/UI/Anchor/Menus/DragonshrineMenu.gml"
+target  = { fn = "entry_is_enabled", at = "head" }
+op      = "guard"
+hook    = "ui.entry_enabled_guard"
+ctx     = "{ perk: entry.perk }"
+on_veto = "return undefined;"
+marker  = "mmapi_entry_enabled_guard"
+
+[[seam]]
+id      = "ui_entry_is_acquired"
+file    = "gml/scripts/UI/Anchor/Menus/DragonshrineMenu.gml"
+target  = { fn = "entry_is_acquired", at = "head" }
+op      = "guard"
+hook    = "ui.entry_acquired_guard"
+ctx     = "{ perk: entry.perk }"
+on_veto = "return undefined;"
+marker  = "mmapi_entry_acquired_guard"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -3552,7 +3552,7 @@ marker  = "mmapi_player_acquire_perk"
 [[seam]]
 id      = "museum_donate_item"
 file    = "gml/scripts/Museum.gml"
-target  = { fn = "donate_item_to_museum", at = "head" }
+target  = { fn = "donate_item_to_museum", at = "after", anchor = '''register_item_to_museum(item_id);''' }
 op      = "emit"
 hook    = "museum.donate_item"
 ctx     = "{ item_id: item_id }"

--- a/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
+++ b/ModsOfMistriaInstallerLib/Seam/Payload/seams.toml
@@ -50,8 +50,8 @@ version = 2
 # hook surface. Keep them in step when adding or removing entries; the
 # shipped-catalog test also holds the docs' count sentences to these numbers.
 [counts]
-hooks = 128
-seams = 139
+hooks = 129
+seams = 140
 engine_fixes = 7
 call_rewrites = 1
 
@@ -519,6 +519,11 @@ doc  = "Fires at the end of the player's move speed computation, after the statu
 name = "player.pass_out"
 kind = "event"
 doc  = "Fires in pass_out(), immediately after end_day() - the day rollover is already under way, stamina is zeroed, and the player is flagged invulnerable when handlers run. ctx is { faint }: true for the 2 AM collapse, false when the player went down to a killing blow but the death was averted (ARI.end_of_day_status tells the cases apart: Fainted for the plain collapse, Protected otherwise). Observation only. A normal bed sleep ends the day without pass_out(), and a death that is not averted runs the dying scene instead - see player.died."
+
+[[hook]]
+name = "player.purchase_perk"
+kind = "event"
+doc  = "Fires at the top of Dragonshrine purchase_entry()"
 
 [[hook]]
 name = "player.renown_delta"
@@ -3741,3 +3746,12 @@ replace = '''
 '''
 marker  = "mmapi_fish_chest_table_lookup"
 provides = ["items.chest_opened"]
+
+[[seam]]
+id      = "dragonshrine_purchase_entry"
+file    = "gml/scripts/UI/Anchor/Menus/DragonshrineMenu.gml"
+target  = { fn = "purchase_entry", at = "head" }
+op      = "emit"
+hook    = "player.purchase_perk"
+ctx     = "{ perk: entry.perk }"
+marker  = "mmapi_dragonshrine_purchase_entry"

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -151,6 +151,8 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [ui.backplate_sprite](hooks/ui.backplate_sprite.md) | filter | Swap the backplate sprites behind the mines menu and spell cards. |
 | [ui.preset_popup_layout](hooks/ui.preset_popup_layout.md) | filter | Resize the customization menu's preset popup frames and grid. |
 | [ui.relationship_row_built](hooks/ui.relationship_row_built.md) | event | Add custom nodes to each NPC row in the relationships journal. |
+| [ui.entry_enabled_guard](hooks/ui.entry_enabled_guard) | guard | Block an entry in the shrine menu from showing as enabled. |
+| [ui.entry_acquried_guard](hooks/ui.entry_acquired_guard) | guard | Block an entry in the shrine menu from showing as bought. |
 | [dialogue.play_guard](hooks/dialogue.play_guard.md) | guard | Block a conversation before it starts. |
 | [dialogue.path](hooks/dialogue.path.md) | filter | Change which conversation plays before it starts. |
 | [dialogue.line](hooks/dialogue.line.md) | filter | Reword any dialogue line before the textbox shows it. |
@@ -316,6 +318,8 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [ui_backplate_sprite_spell_card](seams/ui_backplate_sprite_spell_card.md) | Routes each spell card's backplate sprite through a filter. |
 | [ui_preset_popup_layout](seams/ui_preset_popup_layout.md) | Rebuilds the preset popup's layout constants through a filter each time the popup body is generated. |
 | [ui_relationship_row_built](seams/ui_relationship_row_built.md) | Hands each finished NPC row to mods as the relationships journal builds its list. |
+| [ui_entry_is_enabled](seams/ui_entry_is_enabled.md) | Puts a veto check at the head of `DragonshrineMenu.entry_is_enabled()`. |
+| [ui_entry_is_acquired](seams/ui_entry_is_acquired.md) | Puts a veto check at the head of `DragonshrineMenu.entry_is_acquired()`. |
 | [dialogue_play_guard](seams/dialogue_play_guard.md) | Puts a veto check at the head of `play_conversation()`. |
 | [dialogue_path](seams/dialogue_path.md) | Rebuilds `play_conversation()`'s four arguments through the `dialogue.path` filter. |
 | [dialogue_line](seams/dialogue_line.md) | Filters each localized dialogue line before the textbox shows it. |

--- a/docs/MMAPI/CATALOG.md
+++ b/docs/MMAPI/CATALOG.md
@@ -2,7 +2,7 @@
 
 [← MMAPI](MMAPI.md)
 
-Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **128 hooks**, fed by **139 seams**, **7 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
+Every named hook the seam catalog declares has its own page, as does every seam, engine fix, and call rewrite behind them. The catalog currently declares **131 hooks**, fed by **142 seams**, **7 engine fixes**, and **1 call rewrite**. The authoritative source for all of it is the seam catalog itself, `ModsOfMistriaInstallerLib/Seam/Payload/seams.toml`. See [Seams](SEAMS.md).
 
 Each hook has exactly one kind, and each kind has one registration directive. A handler registered with the wrong directive never runs and produces only a warning in the MMAPI log. See [Hooks](HOOKS.md).
 
@@ -74,6 +74,7 @@ Each hook has exactly one kind, and each kind has one registration directive. A 
 | [player.pass_out](hooks/player.pass_out.md) | event | Know when the player passes out at the end of the day. |
 | [player.died](hooks/player.died.md) | event | Know when the player dies. |
 | [player.acquire_perk](hooks/player.acquire_perk.md) | event | Know when the player acquires a perk. |
+| [player.purchase_perk](hooks/player.purchase_perk.md) | event | Know when the player purchases a perk through the shrine menus. |
 | [player.skill_leveled](hooks/player.skill_leveled.md) | event | Know the moment the player levels up a skill. |
 | [renown.level_gained](hooks/renown.level_gained.md) | event | Know the moment the player gains a renown level. |
 | [renown.rank_gained](hooks/renown.rank_gained.md) | event | Know the moment the player reaches a new renown rank. |
@@ -202,7 +203,7 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [object_interact](seams/object_interact.md) | Puts a claim-scoped override in front of every grid-object interaction. |
 | [node_renderer_set_sprite](seams/node_renderer_set_sprite.md) | Filters the sprite every world node renderer is about to wear. |
 | [store_item_added](seams/store_item_added.md) | Announces every shelf tap that puts an item in the shopping basket. |
-| [museum_donate_item](seams/museum_donate_item.md) | Emits the moment an item is donated to the museum. |
+| [museum_donate_item](seams/museum_donate_item.md) | Emits after an item is registered to the museum. |
 
 ### Player, Actors, And Progression
 
@@ -225,7 +226,8 @@ The anchored engine edits that make the hooks fire. Mod authors never write seam
 | [player_heal_vfx](seams/player_heal_vfx.md) | Puts a veto check at the head of `play_heal_vfx()`. |
 | [player_pass_out](seams/player_pass_out.md) | Emits inside `pass_out()`, right after `end_day()`. |
 | [player_died](seams/player_died.md) | Emits on the final death path, right after the dying scene starts. |
-| [player_acquire_perk](seams/player_acquire_perk.md) | Emits at the head of `acquire_perk()`. |
+| [player_acquire_perk](seams/player_acquire_perk.md) | Emits inside `acquire_perk()`, right after the player's perks have been registered. |
+| [player_purchase_perk](seams/player_purchase_perk.md) | Emits at the head of `purchase_perk()`. |
 | [renown_gains](seams/renown_gains.md) | Emits renown level and rank gains inside `set_renown()`, past its gains-only early return. |
 | [player_status_effect_register](seams/player_status_effect_register.md) | Filters every status effect's fields at the top of `register()`. |
 | [player_status_effect_cancel](seams/player_status_effect_cancel.md) | Emits at the head of `StatusEffectManager.cancel()`, before any lookup. |

--- a/docs/MMAPI/hooks/museum.donate_item.md
+++ b/docs/MMAPI/hooks/museum.donate_item.md
@@ -6,13 +6,13 @@ Know when an item is donated to the museum.
 
 ## Contract
 
-Fires at the top of `donate_item_to_museum()`, before the item is registered to the collection and before the pending renown entry is pushed. ctx is `{ item_id }`.
+Fires within `donate_item_to_museum()`, after the item is registered to the collection but before the pending renown entry is pushed. ctx is `{ item_id }`.
 
 This hook is observation only. The `DonationResult` the function goes on to compute (progress made, completed set, rewards) is decided after the emit, so a handler sees the donation before the museum knows what it amounts to. It fires once per donated item, from the museum donation menu (and the engine's test suite). Save load and the `ALL_UNLOCKS` new-game path write donations through `register_item_to_museum()` directly and never fire this hook, so handlers see genuine player donations only.
 
 | | |
 | --- | --- |
-| **Fires** | At the top of `donate_item_to_museum()`, before the item is registered or the renown entry is pushed. |
+| **Fires** | At the top of `donate_item_to_museum()`, after the item is registered but before the renown entry is pushed. |
 | **ctx** | `{ item_id }` |
 | **Kind contract** | The callback observes the moment. Its return value is ignored. |
 
@@ -39,7 +39,7 @@ mmapi_on("museum.donate_item", curator_ledger_museum_donate_item);
 
 ## Engine Wiring
 
-- Seam [`museum_donate_item`](../seams/museum_donate_item.md) dispatches from `gml/scripts/Museum.gml`, at the head of `donate_item_to_museum()`.
+- Seam [`museum_donate_item`](../seams/museum_donate_item.md) dispatches from `gml/scripts/Museum.gml`, within `donate_item_to_museum()`.
 
 ## See Also
 

--- a/docs/MMAPI/seams/museum_donate_item.md
+++ b/docs/MMAPI/seams/museum_donate_item.md
@@ -17,7 +17,7 @@ Emits the moment an item is donated to the museum.
 
 ## The Edit
 
-The generated emit lands at the head of `donate_item_to_museum()`. It calls `mmapi_emit("museum.donate_item", { item_id: item_id })` in the uniform try/catch shape. The head placement puts the emit before everything the donation does: `register_item_to_museum()` (the progress write and its `T2R` fact), the pending renown entry push, and the set-progress scan that decides the `DonationResult`.
+The generated emit lands within `donate_item_to_museum()`. It calls `mmapi_emit("museum.donate_item", { item_id: item_id })` in the uniform try/catch shape. The head placement puts the emit after `register_item_to_museum()` (the progress write and its `T2R` fact), but before the rest of the donation: the pending renown entry push, and the set-progress scan that decides the `DonationResult`.
 
 `donate_item_to_museum()` is the donation menu's single entry point, so the hook sees exactly the player's donations (plus those of the engine's test suite). The engine's two other progress writers, save load and the `ALL_UNLOCKS` new-game path, call `register_item_to_museum()` directly, below this seam's reach. That is what keeps load-time restoration from replaying as donations. With zero handlers the seam is behaviorally identical to pristine.
 


### PR DESCRIPTION
Adds hooks:
- player.purchase_perk (event reading when the player purchases an entry in Dragonshrine Menu)
- ui.entry_enabled_guard (guard vetoing how an entry in the Dragonshrine Menu shows as enabled)
- ui.entry_acquired_guard (guard vetoing how an entry in the Dragonshrine Menu shows as acquired)

Adds seams:
- dragonshrine_purchase_entry
- ui_entry_is_enabled
- ui_entry_is_acquired


Changes the behavior of:
- museum_donate_item/museum.donate_item: now fires after `register_item_to_museum();`. this fixes logic for any mod using the hook to keep track of how many items have been donated to the museum
- player_acquire_perk/player.acquire_perk: now fires after the perk flags have been set, fixing logic for any mod needing to change the perk flags

Notes:
- entry_enabled/entry_acquired seams can probably be merged? not sure how this works but they solve related problems
- Documentation needs to be adjusted; either incomplete or no longer accurate
- Wasn't sure how to name these hooks/seams well, feel free to change them as you see fit
- for player.acquire_perk - the specific use case atm is to immediately disable one/both of the perk flags, so I'm not sure if we should be keeping it as an event hook or changing the hook type. left it as is for integrity purposes, but open to clarifying the use case/finding an alternate solution

As always, feel free to ask on discord for any necessary clarification :)